### PR TITLE
fast_htmlパッケージのテスト環境を整える

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "ecow",
  "fast_dom",
  "log",
+ "serde_json",
  "tree",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
 name = "fast_html"
 version = "0.1.0"
 dependencies = [
+ "assert-json-diff",
  "criterion",
  "ecow",
  "fast_dom",

--- a/components/fast_html/Cargo.toml
+++ b/components/fast_html/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tree     = { path = "../../utilities/tree" }
-fast_dom = { path = "../fast_dom" }
-ecow     = "0.2.0"
-log      = "0.4.20"
+tree       = { path = "../../utilities/tree" }
+fast_dom   = { path = "../fast_dom" }
+ecow       = "0.2.0"
+log        = "0.4.20"
+serde_json = "1.0.111"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/components/fast_html/Cargo.toml
+++ b/components/fast_html/Cargo.toml
@@ -13,7 +13,8 @@ log        = "0.4.20"
 serde_json = "1.0.111"
 
 [dev-dependencies]
-criterion = { version = "0.5.1", features = ["html_reports"] }
+assert-json-diff = "2.0.2"
+criterion        = { version = "0.5.1", features = ["html_reports"] }
 
 [[bench]]
 name    = "parse_html"

--- a/components/fast_html/src/debugger/mod.rs
+++ b/components/fast_html/src/debugger/mod.rs
@@ -82,16 +82,16 @@ fn element_node_to_json(node: &Element) -> serde_json::Value {
   }
 
   if attributes.is_empty() {
-    return json!({
+    json!({
       "type": "element",
       "tag": node.tag_name().as_str(),
-    });
+    })
   } else {
-    return json!({
+    json!({
       "type": "element",
       "tag": node.tag_name().as_str(),
       "attributes": attributes,
-    });
+    })
   }
 }
 
@@ -118,19 +118,19 @@ fn dom_to_json_core(
 
   if let Some(text_node) = root.as_maybe_text() {
     if !text_node.value.borrow().trim().is_empty() {
-      json = text_node_to_json(&text_node);
+      json = text_node_to_json(text_node);
     }
   }
 
   if let Some(element_node) = root.as_maybe_element() {
-    json = element_node_to_json(&element_node);
+    json = element_node_to_json(element_node);
   }
 
-  if let Some(_) = root.as_maybe_document() {
+  if root.as_maybe_document().is_some() {
     json = document_node_to_json();
   }
 
-  if children.len() > 0 {
+  if !children.is_empty() {
     json["children"] = json!(children);
   }
 

--- a/components/fast_html/tests/nesting.rs
+++ b/components/fast_html/tests/nesting.rs
@@ -1,0 +1,73 @@
+extern crate fast_html;
+
+use fast_html::debugger::*;
+
+use assert_json_diff::*;
+use serde_json::json;
+
+#[test]
+fn valid_nest() {
+  let html = r#"
+  <h1>This is heading</h1>
+  <p>This is paragraph</p>
+  <p>This <mark>keyword</mark> is important</p>
+  "#;
+
+  let expected = json!(
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "type": "text",
+              "value": "This is heading"
+            }
+          ],
+          "tag": "h1",
+          "type": "element"
+        },
+        {
+          "children": [
+            {
+              "type": "text",
+              "value": "This is paragraph"
+            }
+          ],
+          "tag": "p",
+          "type": "element"
+        },
+        {
+          "children": [
+            {
+              "type": "text",
+              "value": "This "
+            },
+            {
+              "children": [
+                {
+                  "type": "text",
+                  "value": "keyword"
+                }
+              ],
+              "tag": "mark",
+              "type": "element"
+            },
+            {
+              "type": "text",
+              "value": " is important"
+            }
+          ],
+          "tag": "p",
+          "type": "element"
+        }
+      ],
+      "tag": "body",
+      "type": "element"
+    }
+  );
+
+  let document = get_document_from_html(html);
+  let actual = dom_body_to_json(&document);
+
+  assert_json_eq!(actual, expected);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,11 @@ fn run_fast_html() {
   let document = fast_html::debugger::get_document_from_html(target);
 
   fast_html::debugger::print_dom_tree(&document);
+
+  println!("-------------------");
+
+  let json = fast_html::debugger::dom_to_json_string(&document);
+  println!("{}", json);
 }
 
 fn run_css() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,11 @@ fn run_html() {
 
   html::debugger::print_dom_tree(&document);
 
-  //println!("-------------------");
+  println!("-------------------");
 
-  //let json = html::debugger::dom_in_body_to_json(&document);
+  let json = html::debugger::dom_to_json(&document);
 
-  //println!("{}", json);
+  println!("{}", json);
 }
 
 fn run_fast_html() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,15 +11,13 @@ fn run_html() {
 
   println!("-------------------");
 
-  let json = html::debugger::dom_to_json(&document);
+  let json = html::debugger::dom_in_body_to_json(&document);
 
   println!("{}", json);
 }
 
 fn run_fast_html() {
-  let target = r#"<h1>This is heading</h1>
-  <p>This is paragraph</p>
-  <p>This <mark>keyword</mark> is important</p>"#;
+  let target = r#"<p>paragraph1<p>paragraph2"#;
 
   let document = fast_html::debugger::get_document_from_html(target);
 
@@ -27,7 +25,7 @@ fn run_fast_html() {
 
   println!("-------------------");
 
-  let json = fast_html::debugger::dom_to_json_string(&document);
+  let json = fast_html::debugger::dom_body_to_json_string(&document);
   println!("{}", json);
 }
 


### PR DESCRIPTION
DOM構造をJSON形式に変換する関数を実装し、ネスト構造のテストを直感的に書けるようにする。

JSON化は`serde_json`で、テストでのJSON構造比較は`assert-json-diff`で行うため、これらのパッケージも導入する。