### PR TITLE
[fast_html] 終了タグが欠けたpタグを正常に処理できるように

### DIFF
--- a/components/fast_html/tests/missing_end_tag.rs
+++ b/components/fast_html/tests/missing_end_tag.rs
@@ -1,0 +1,45 @@
+extern crate fast_html;
+
+use fast_html::debugger::*;
+
+use assert_json_diff::*;
+use serde_json::json;
+
+#[test]
+fn missing_p_end_tag() {
+  let html = r#"<p>paragraph1<p>paragraph2"#;
+
+  let excepted = json!(
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "value": "paragraph1",
+              "type": "text"
+            }
+          ],
+          "tag": "p",
+          "type": "element"
+        },
+        {
+          "children": [
+            {
+              "value": "paragraph2",
+              "type": "text"
+            }
+          ],
+          "tag": "p",
+          "type": "element"
+        }
+      ],
+      "tag": "body",
+      "type": "element"
+    }
+  );
+
+  let document = get_document_from_html(html);
+  let actual = dom_body_to_json(&document);
+
+  assert_json_eq!(excepted, actual);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 use std::env;
 
 fn run_html() {
-  let target = r#"<h1>This is heading</h1>
-  <p>This is paragraph</p>
-  <p>This <mark>keyword</mark> is important</p>"#;
+  let target = r#"<p>paragraph1<p>paragraph2"#;
 
   let document = html::debugger::get_document_from_html(target);
 


### PR DESCRIPTION
## 対処する問題

fast_htmlでは、終了タグが欠けたpタグを正常なDOMに変換することができなかった。

tokenizerで、最後のTextトークンを発行する前に、EOF判定をしてしまっていたのが原因である。

### 解析対象HTML

```html
<p>paragraph1<p>paragraph2
```

### 正しい構造（html）

```
     Running `target/debug/learn-browser-works html`
[2024-01-19T11:29:34Z DEBUG html::tokenizer] Tokenizer State: switch to TagOpen
[2024-01-19T11:29:34Z DEBUG html::tokenizer] Tokenizer State: switch to TagName
[2024-01-19T11:29:34Z DEBUG html::tokenizer] Tokenizer State: switch to Data
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Tag { tag_name: "p", attributes: [], self_closing: false, self_closing_acknowledged: false, is_end_tag: false }
[2024-01-19T11:29:34Z WARN  html::tree_builder] Unexpected start tag: p
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Builder State: switch to BeforeHtml
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Builder State: switch to BeforeHead
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Builder State: switch to InHead
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Builder State: switch to AfterHead
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Builder State: switch to InBody
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('p')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('a')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('r')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('a')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('g')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('r')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('a')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('p')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('h')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('1')
[2024-01-19T11:29:34Z DEBUG html::tokenizer] Tokenizer State: switch to TagOpen
[2024-01-19T11:29:34Z DEBUG html::tokenizer] Tokenizer State: switch to TagName
[2024-01-19T11:29:34Z DEBUG html::tokenizer] Tokenizer State: switch to Data
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Tag { tag_name: "p", attributes: [], self_closing: false, self_closing_acknowledged: false, is_end_tag: false }
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('p')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('a')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('r')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('a')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('g')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('r')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('a')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('p')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('h')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] Character('2')
[2024-01-19T11:29:34Z DEBUG html::tree_builder] EOF
|-Document
    |-Element { data: Unknown(HTMLElement { tag_name: "html" }) }
        |-Element { data: Unknown(HTMLElement { tag_name: "head" }) }
        |-Element { data: Unknown(HTMLElement { tag_name: "body" }) }
            |-Element { data: Unknown(HTMLElement { tag_name: "p" }) }
                |-Text("paragraph1")
            |-Element { data: Unknown(HTMLElement { tag_name: "p" }) }
                |-Text("paragraph2")
```

### 不完全な構造（fast_html）

```
     Running `target/debug/learn-browser-works fast_html`
[2024-01-19T11:25:22Z DEBUG fast_html::tokenizer] Tokenizer State: switch to TagOpen
[2024-01-19T11:25:22Z DEBUG fast_html::tokenizer] Tokenizer State: switch to TagName
[2024-01-19T11:25:22Z DEBUG fast_html::tokenizer] Tokenizer State: switch to Data
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] Tag { tag_name: "p", attributes: [], self_closing: false, self_closing_acknowledged: false, is_end_tag: false }
[2024-01-19T11:25:22Z WARN  fast_html::tree_builder] Unexpected start tag: p
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] TreeBuilder InsertMode: switch to BeforeHtml
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] TreeBuilder InsertMode: switch to BeforeHead
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] TreeBuilder InsertMode: switch to InHead
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] TreeBuilder InsertMode: switch to AfterHead
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] TreeBuilder InsertMode: switch to InBody
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] Text("paragraph1")
[2024-01-19T11:25:22Z DEBUG fast_html::tokenizer] Tokenizer State: switch to TagOpen
[2024-01-19T11:25:22Z DEBUG fast_html::tokenizer] Tokenizer State: switch to TagName
[2024-01-19T11:25:22Z DEBUG fast_html::tokenizer] Tokenizer State: switch to Data
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] Tag { tag_name: "p", attributes: [], self_closing: false, self_closing_acknowledged: false, is_end_tag: false }
[2024-01-19T11:25:22Z DEBUG fast_html::tree_builder] EOF
|-Document
    |-Element { tag_name: "html" }
        |-Element { tag_name: "head" }
        |-Element { tag_name: "body" }
            |-Element { tag_name: "p" }
                |-Text("paragraph1")
            |-Element { tag_name: "p" }
```

## 一応ベンチマーク

何回か実行しているので、`change`は当てにならないが…

<img width="653" alt="スクリーンショット 2024-01-20 6 27 49" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/aad532ee-e462-4b8c-96bc-f355b5f31bf4">
<img width="653" alt="スクリーンショット 2024-01-20 6 27 40" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/f024201d-f3d1-4267-a88d-d189dd9ab2cf">
