### PR TITLE
[fast_html] 属性つきのタグに対応

### DIFF
--- a/components/fast_html/Cargo.toml
+++ b/components/fast_html/Cargo.toml
@@ -25,3 +25,8 @@ harness = false
 name    = "tokenizer"
 path    = "benches/tokenizer.rs"
 harness = false
+
+[[bench]]
+name    = "with_attributes"
+path    = "benches/with_attributes.rs"
+harness = false

--- a/components/fast_html/benches/with_attributes.rs
+++ b/components/fast_html/benches/with_attributes.rs
@@ -1,0 +1,18 @@
+extern crate fast_html;
+
+use fast_html::debugger::*;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn parse_html_benchmark(c: &mut Criterion) {
+  c.bench_function("with_attributes_fast", |b| {
+    b.iter(|| {
+      let html =
+        r#"<a href="https://example.com" target="_blank">sample link</a>"#;
+      get_document_from_html(black_box(html));
+    })
+  });
+}
+
+criterion_group!(benches, parse_html_benchmark);
+criterion_main!(benches);

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -187,7 +187,7 @@ impl<'a> Tokenizer<'a> {
         self.append_replacement_char_to_tag_name();
       }
       b if b.is_ascii_whitespace() => {
-        unimplemented!("undefined State::BeforeAttributeName");
+        self.switch_to(State::BeforeAttributeName);
       }
       _ => {
         noop!();

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -544,8 +544,15 @@ impl<'a> Tokenizer<'a> {
   }
 
   fn read_next_skipped_whitespace(&mut self) -> u8 {
-    //self.stream.advance();
-    self.stream.skip_while(|b| b.is_ascii_whitespace());
+    let start = self.stream.idx;
+    let rest = &self.stream.data()[start..];
+
+    let end = rest
+      .iter()
+      .position(|&b| !b.is_ascii_whitespace())
+      .unwrap_or(self.stream.len() - start);
+
+    self.stream.advance_by(end);
     self.stream.current_cpy().unwrap()
   }
 

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -231,17 +231,17 @@ impl<'a> Tokenizer<'a> {
 
     match c {
       b'/' | b'>' => {
-        self.reconsume_in_state(State::AfterAttributeName);
+        self.switch_to(State::AfterAttributeName);
       }
       _ if self.stream.is_eof() => {
-        self.reconsume_in_state(State::AfterAttributeName);
+        self.switch_to(State::AfterAttributeName);
       }
       b'=' => {
         warn!("unexpected-equals-sign-before-attribute-name");
         self.switch_to(State::AttributeName);
       }
       _ => {
-        self.reconsume_in_state(State::AttributeName);
+        self.switch_to(State::AttributeName);
       }
     }
 
@@ -259,18 +259,19 @@ impl<'a> Tokenizer<'a> {
 
     // read_currentに進む前にEOFチェック
     if self.stream.is_eof() {
-      self.reconsume_in_state(State::AfterAttributeName);
+      self.switch_to(State::AfterAttributeName);
       return None;
     }
 
     let c = self.read_current();
+    self.stream.advance();
 
     match c {
       _ if c.is_ascii_whitespace() => {
-        self.reconsume_in_state(State::AfterAttributeName);
+        self.switch_to(State::AfterAttributeName);
       }
       b'/' | b'>' => {
-        self.reconsume_in_state(State::AfterAttributeName);
+        self.switch_to(State::AfterAttributeName);
       }
       b'=' => {
         self.switch_to(State::BeforeAttributeValue);
@@ -297,6 +298,8 @@ impl<'a> Tokenizer<'a> {
 
   fn process_before_attribute_value_state(&mut self) -> Option<Token> {
     let c = self.read_next_skipped_whitespace();
+
+    self.stream.advance();
 
     match c {
       b'"' => {
@@ -363,6 +366,8 @@ impl<'a> Tokenizer<'a> {
 
   fn process_after_attribute_value_quoted_state(&mut self) -> Option<Token> {
     let c = self.read_next();
+
+    self.stream.advance();
 
     match c {
       _ if c.is_ascii_whitespace() => {
@@ -539,7 +544,7 @@ impl<'a> Tokenizer<'a> {
   }
 
   fn read_next_skipped_whitespace(&mut self) -> u8 {
-    self.stream.advance();
+    //self.stream.advance();
     self.stream.skip_while(|b| b.is_ascii_whitespace());
     self.stream.current_cpy().unwrap()
   }

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -296,7 +296,26 @@ impl<'a> Tokenizer<'a> {
   }
 
   fn process_before_attribute_value_state(&mut self) -> Option<Token> {
-    todo!("process_before_attribute_value_state");
+    let c = self.read_next_skipped_whitespace();
+
+    match c {
+      b'"' => {
+        self.switch_to(State::AttributeValueDoubleQuoted);
+      }
+      b'\'' => {
+        self.switch_to(State::AttributeValueSingleQuoted);
+      }
+      b'>' => {
+        warn!("missing-attribute-value");
+        self.switch_to(State::Data);
+        return Some(self.emit_current_token());
+      }
+      _ => {
+        self.reconsume_in_state(State::AttributeValueUnQuoted);
+      }
+    }
+
+    None
   }
 
   fn process_attribute_value_double_quoted_state(&mut self) -> Option<Token> {

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -362,7 +362,30 @@ impl<'a> Tokenizer<'a> {
   }
 
   fn process_after_attribute_value_quoted_state(&mut self) -> Option<Token> {
-    todo!("process_after_attribute_value_quoted_state");
+    let c = self.read_next();
+
+    match c {
+      _ if c.is_ascii_whitespace() => {
+        self.switch_to(State::BeforeAttributeName);
+      }
+      b'/' => {
+        unimplemented!("self.switch_to(State::SelfClosingStartTag);");
+      }
+      b'>' => {
+        self.switch_to(State::Data);
+        return Some(self.emit_current_token());
+      }
+      _ if self.stream.is_eof() => {
+        warn!("eof-in-tag");
+        return Some(self.emit_eof());
+      }
+      _ => {
+        warn!("missing-whitespace-between-attributes");
+        self.reconsume_in_state(State::BeforeAttributeName);
+      }
+    }
+
+    None
   }
 
   /* -------------------------------------------- */

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -53,6 +53,26 @@ impl<'a> Tokenizer<'a> {
         State::TagOpen => self.process_tag_open_state(),
         State::TagName => self.process_tag_name_state(),
         State::EndTagOpen => self.process_end_tag_open_state(),
+        State::BeforeAttributeName => {
+          self.process_before_attribute_name_state()
+        }
+        State::AttributeName => self.process_attribute_name_state(),
+        State::AfterAttributeName => self.process_after_attribute_name_state(),
+        State::BeforeAttributeValue => {
+          self.process_before_attribute_value_state()
+        }
+        State::AttributeValueDoubleQuoted => {
+          self.process_attribute_value_double_quoted_state()
+        }
+        State::AttributeValueSingleQuoted => {
+          self.process_attribute_value_single_quoted_state()
+        }
+        State::AttributeValueUnQuoted => {
+          self.process_attribute_value_unquoted_state()
+        }
+        State::AfterAttributeValueQuoted => {
+          self.process_after_attribute_value_quoted_state()
+        }
       };
 
       if let Some(token) = token {
@@ -203,6 +223,38 @@ impl<'a> Tokenizer<'a> {
     }
 
     None
+  }
+
+  fn process_before_attribute_name_state(&mut self) -> Option<Token> {
+    todo!("process_before_attribute_name_state");
+  }
+
+  fn process_attribute_name_state(&mut self) -> Option<Token> {
+    todo!("process_attribute_name_state");
+  }
+
+  fn process_after_attribute_name_state(&mut self) -> Option<Token> {
+    todo!("process_after_attribute_name_state");
+  }
+
+  fn process_before_attribute_value_state(&mut self) -> Option<Token> {
+    todo!("process_before_attribute_value_state");
+  }
+
+  fn process_attribute_value_double_quoted_state(&mut self) -> Option<Token> {
+    todo!("process_attribute_value_double_quoted_state");
+  }
+
+  fn process_attribute_value_single_quoted_state(&mut self) -> Option<Token> {
+    todo!("process_attribute_value_single_quoted_state");
+  }
+
+  fn process_attribute_value_unquoted_state(&mut self) -> Option<Token> {
+    todo!("process_attribute_value_unquoted_state");
+  }
+
+  fn process_after_attribute_value_quoted_state(&mut self) -> Option<Token> {
+    todo!("process_after_attribute_value_quoted_state");
   }
 
   /* -------------------------------------------- */

--- a/components/fast_html/src/tokenizer/state.rs
+++ b/components/fast_html/src/tokenizer/state.rs
@@ -5,4 +5,14 @@ pub enum State {
   TagName,
   TagOpen,
   EndTagOpen,
+
+  BeforeAttributeName,
+  AttributeName,
+  AfterAttributeName,
+
+  BeforeAttributeValue,
+  AttributeValueDoubleQuoted,
+  AttributeValueSingleQuoted,
+  AttributeValueUnQuoted,
+  AfterAttributeValueQuoted,
 }

--- a/components/fast_html/src/tokenizer/stream.rs
+++ b/components/fast_html/src/tokenizer/stream.rs
@@ -37,6 +37,15 @@ impl<'a, T: Eq + Copy> Stream<'a, T> {
   pub fn expect_and_skip_cond(&mut self, expect: T) -> bool {
     self.expect_and_skip(expect).is_some()
   }
+
+  pub fn skip_while(&mut self, predicate: impl Fn(T) -> bool) {
+    while let Some(c) = self.current_cpy() {
+      if !predicate(c) {
+        break;
+      }
+      self.advance();
+    }
+  }
 }
 
 impl<'a, T> Stream<'a, T> {

--- a/components/fast_html/src/tokenizer/stream.rs
+++ b/components/fast_html/src/tokenizer/stream.rs
@@ -37,15 +37,6 @@ impl<'a, T: Eq + Copy> Stream<'a, T> {
   pub fn expect_and_skip_cond(&mut self, expect: T) -> bool {
     self.expect_and_skip(expect).is_some()
   }
-
-  pub fn skip_while(&mut self, predicate: impl Fn(T) -> bool) {
-    while let Some(c) = self.current_cpy() {
-      if !predicate(c) {
-        break;
-      }
-      self.advance();
-    }
-  }
 }
 
 impl<'a, T> Stream<'a, T> {

--- a/components/fast_html/src/tokenizer/token.rs
+++ b/components/fast_html/src/tokenizer/token.rs
@@ -143,6 +143,13 @@ impl Attribute {
       value: EcoString::new(),
     }
   }
+
+  pub fn new_name_of(name: &str) -> Self {
+    Attribute {
+      name: EcoString::from(name),
+      value: EcoString::new(),
+    }
+  }
 }
 
 impl Deref for Attribute {

--- a/components/fast_html/tests/with_attributes.rs
+++ b/components/fast_html/tests/with_attributes.rs
@@ -1,0 +1,39 @@
+extern crate fast_html;
+
+use fast_html::debugger::*;
+
+use assert_json_diff::*;
+use serde_json::json;
+
+#[test]
+fn with_attributes() {
+  let html = r#"<a href="https://example.com" target="_blank">sample link</a>"#;
+
+  let excepted = json!(
+    {
+      "children": [
+        {
+          "attributes": {
+            "href": "https://example.com",
+            "target": "_blank"
+          },
+          "children": [
+            {
+              "type": "text",
+              "value": "sample link"
+            }
+          ],
+          "tag": "a",
+          "type": "element"
+        }
+      ],
+      "tag": "body",
+      "type": "element"
+    }
+  );
+
+  let document = get_document_from_html(html);
+  let actual = dom_body_to_json(&document);
+
+  assert_json_eq!(excepted, actual);
+}

--- a/components/html/Cargo.toml
+++ b/components/html/Cargo.toml
@@ -27,3 +27,8 @@ harness = false
 name    = "tokenizer"
 path    = "benches/tokenizer.rs"
 harness = false
+
+[[bench]]
+name    = "with_attributes"
+path    = "benches/with_attributes.rs"
+harness = false

--- a/components/html/benches/with_attributes.rs
+++ b/components/html/benches/with_attributes.rs
@@ -1,0 +1,18 @@
+extern crate html;
+
+use html::debugger::*;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn parse_html_benchmark(c: &mut Criterion) {
+  c.bench_function("with_attributes", |b| {
+    b.iter(|| {
+      let html =
+        r#"<a href="https://example.com" target="_blank">sample link</a>"#;
+      get_document_from_html(black_box(html));
+    })
+  });
+}
+
+criterion_group!(benches, parse_html_benchmark);
+criterion_main!(benches);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 use std::env;
 
-fn run_html() {
-  let target = r#"<p>paragraph1<p>paragraph2"#;
+const TARGET_HTML: &str =
+  r#"<a href="https://example.com" target="_blank">sample link</a>"#;
 
-  let document = html::debugger::get_document_from_html(target);
+fn run_html() {
+  let document = html::debugger::get_document_from_html(TARGET_HTML);
 
   html::debugger::print_dom_tree(&document);
 
@@ -15,9 +16,7 @@ fn run_html() {
 }
 
 fn run_fast_html() {
-  let target = r#"<p>paragraph1<p>paragraph2"#;
-
-  let document = fast_html::debugger::get_document_from_html(target);
+  let document = fast_html::debugger::get_document_from_html(TARGET_HTML);
 
   fast_html::debugger::print_dom_tree(&document);
 


### PR DESCRIPTION
## 目的

`fast_html`も属性付きのタグを解析できるようにする。

## 比較

`html`

<img width="653" alt="スクリーンショット 2024-01-20 9 32 51" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/4f4d5c15-ee17-4feb-8c6f-eee54686ac1e">

`fast_html`

<img width="653" alt="スクリーンショット 2024-01-20 9 33 00" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/1836a213-8439-4973-b287-5d1e154b0831">

[fast_html/tokenizer: read_next_skipped_whitespaceを最適化](https://github.com/tetracalibers/learn-browsers-work/pull/5/commits/793a3a7ce539823bad431f5707f5dbd165d0417d)でやや改善？

<img width="653" alt="スクリーンショット 2024-01-20 9 41 37" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/f1db6ca3-e0d5-4d30-8152-586c72d0a36a">
