### PR TITLE
[fast_html] noopマクロを削除し、コメントに置き換え

### DIFF
--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -16,10 +16,6 @@ use log::{debug, warn};
 
 use ecow::EcoVec;
 
-macro_rules! noop {
-  () => {};
-}
-
 const REPLACEMENT_CHARACTER: char = '\u{FFFD}';
 
 pub struct Tokenizer<'a> {
@@ -116,7 +112,7 @@ impl<'a> Tokenizer<'a> {
         return Some(self.emit_text(bytes));
       }
       _ => {
-        noop!();
+        // noop
       }
     }
 
@@ -191,7 +187,7 @@ impl<'a> Tokenizer<'a> {
         self.switch_to(State::BeforeAttributeName);
       }
       _ => {
-        noop!();
+        // noop
       }
     }
 
@@ -285,7 +281,7 @@ impl<'a> Tokenizer<'a> {
         self.append_char_to_attribute_name(c as char);
       }
       _ => {
-        noop!();
+        // noop
       }
     }
 
@@ -349,7 +345,7 @@ impl<'a> Tokenizer<'a> {
         self.append_char_to_attribute_value(REPLACEMENT_CHARACTER);
       }
       _ => {
-        noop!();
+        // noop
       }
     }
 


### PR DESCRIPTION
無駄すぎる気がしたので…（置き換えたところで劇的な変化があるわけではないが）

<img width="653" alt="スクリーンショット 2024-01-20 9 51 04" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/c457c63e-e3be-4e30-b1c5-ed82f494f6dd">
<img width="653" alt="スクリーンショット 2024-01-20 9 50 56" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/9f1eb6d9-b212-41d0-8444-77ade0d2e452">
<img width="653" alt="スクリーンショット 2024-01-20 9 50 49" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/f1ed020b-1dc3-4a5f-817a-dac8729de156">
