### PR TITLE
[fast_html] Tokenizerのロジックを整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Challenge to build a toy browser in Rust
 cargo run -- html
 ```
 
-パーサーの状態遷移など、より細かいログを見たい場合は、次のように環境変数を添えてください。
+ログレベルを`debug`にすると、パーサーの状態遷移やトークン発行のログが表示されるようになります。
+
+```bash
+RUST_LOG=debug cargo run -- html
+```
+
+ログレベルを`trace`にすると、Tokenizerの各状態で検出した処理対象の文字も表示されるようになります。
 
 ```bash
 RUST_LOG=trace cargo run -- html

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -94,7 +94,7 @@ impl<'a> Tokenizer<'a> {
   /* -------------------------------------------- */
 
   fn process_data_state(&mut self) -> Option<Token> {
-    let bytes = self.read_to_many(&[b'<', b'&', b'\0']);
+    let bytes = self.read_to_oneof(&[b'<', b'&', b'\0']);
 
     trace!("-- Data: {}", bytes_to_string(bytes));
 
@@ -168,7 +168,7 @@ impl<'a> Tokenizer<'a> {
 
   fn process_tag_name_state(&mut self) -> Option<Token> {
     let bytes =
-      self.read_to_many(&[b'/', b'>', b'\0', b'\t', b'\n', b' ', b'\x0C']);
+      self.read_to_oneof(&[b'/', b'>', b'\0', b'\t', b'\n', b' ', b'\x0C']);
 
     trace!("-- TagName: {}", bytes_to_string(bytes));
 
@@ -336,7 +336,7 @@ impl<'a> Tokenizer<'a> {
   }
 
   fn process_attribute_value_double_quoted_state(&mut self) -> Option<Token> {
-    let bytes = self.read_to_many(&[b'"', b'&', b'\0']);
+    let bytes = self.read_to_oneof(&[b'"', b'&', b'\0']);
 
     trace!("-- AttributeValueDoubleQuoted: {}", bytes_to_string(bytes));
 
@@ -573,7 +573,7 @@ impl<'a> Tokenizer<'a> {
 
   // cに遭遇するまで読み進める
   // cを含む位置を返すので注意
-  fn read_to_many(&mut self, c: &[u8]) -> &'a [u8] {
+  fn read_to_oneof(&mut self, c: &[u8]) -> &'a [u8] {
     let start = self.stream.idx;
     let bytes = &self.stream.data()[start..];
 

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -238,7 +238,7 @@ impl<'a> Tokenizer<'a> {
   }
 
   fn process_before_attribute_name_state(&mut self) -> Option<Token> {
-    let c = self.read_next_skipped_whitespace();
+    let c = self.read_current_skipped_whitespace();
 
     trace!("-- BeforeAttributeName: {}", c as char);
 
@@ -311,7 +311,7 @@ impl<'a> Tokenizer<'a> {
   }
 
   fn process_before_attribute_value_state(&mut self) -> Option<Token> {
-    let c = self.read_next_skipped_whitespace();
+    let c = self.read_current_skipped_whitespace();
 
     trace!("-- BeforeAttributeValue: {}", c as char);
 
@@ -547,7 +547,7 @@ impl<'a> Tokenizer<'a> {
     self.stream.current_cpy().unwrap()
   }
 
-  fn read_next_skipped_whitespace(&mut self) -> u8 {
+  fn read_current_skipped_whitespace(&mut self) -> u8 {
     let start = self.stream.idx;
     let rest = &self.stream.data()[start..];
 

--- a/components/fast_html/src/tokenizer/stream.rs
+++ b/components/fast_html/src/tokenizer/stream.rs
@@ -60,10 +60,6 @@ impl<'a, T> Stream<'a, T> {
     self.idx += step;
   }
 
-  pub fn reconsume(&mut self) {
-    self.idx -= 1;
-  }
-
   pub fn current(&self) -> Option<&T> {
     self.data.get(self.idx)
   }


### PR DESCRIPTION
仕様でreconsumeせよ、と書かれている箇所でreconsumeしていなかったり、謎の位置でstream.advanceしていたりと、流れが追いづらく、仕様と合致していないように見えるコードになっていた。

仕様通りの箇所でreconsumeできるように、`reconsume_in`関数などの定義を調整する。
具体的には、次のようなルールを敷き、各状態のハンドラは仕様通りのロジックに見えるようにする。

- 各状態のハンドラでは、`read_current`の結果によって処理を分岐する
- `switch_to`を呼び出せば、自動的に`stream.advance`で次の文字に進む
- 今の文字を維持して状態だけ切り替えたい場合は、`reconsume_in`を使う

その他、`trace`ログを追加する、関数名をより適切な名称に変更する、などコードが読みやすくデバッグしやすいように微修正した。