### PR TITLE
[fast_html] DOCTYPEを解析できるようにする

### DIFF
--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -70,6 +70,9 @@ impl<'a> Tokenizer<'a> {
         State::AfterAttributeValueQuoted => {
           self.process_after_attribute_value_quoted_state()
         }
+        State::MarkupDeclarationOpen => {
+          self.process_markup_declaration_open_state()
+        }
         State::DOCTYPE => self.process_doctype_state(),
         State::BeforeDOCTYPEName => self.process_before_doctype_name_state(),
         State::DOCTYPEName => self.process_doctype_name_state(),
@@ -412,6 +415,10 @@ impl<'a> Tokenizer<'a> {
     }
 
     None
+  }
+
+  fn process_markup_declaration_open_state(&mut self) -> Option<Token> {
+    todo!("process_markup_declaration_open_state");
   }
 
   fn process_doctype_state(&mut self) -> Option<Token> {

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -70,6 +70,11 @@ impl<'a> Tokenizer<'a> {
         State::AfterAttributeValueQuoted => {
           self.process_after_attribute_value_quoted_state()
         }
+        State::DOCTYPE => self.process_doctype_state(),
+        State::BeforeDOCTYPEName => self.process_before_doctype_name_state(),
+        State::DOCTYPEName => self.process_doctype_name_state(),
+        State::AfterDOCTYPEName => self.process_after_doctype_name_state(),
+        State::BogusDOCTYPE => self.process_bogus_doctype_state(),
       };
 
       if let Some(token) = token {
@@ -407,6 +412,26 @@ impl<'a> Tokenizer<'a> {
     }
 
     None
+  }
+
+  fn process_doctype_state(&mut self) -> Option<Token> {
+    todo!("process_doctype_state");
+  }
+
+  fn process_before_doctype_name_state(&mut self) -> Option<Token> {
+    todo!("process_before_doctype_name_state");
+  }
+
+  fn process_doctype_name_state(&mut self) -> Option<Token> {
+    todo!("process_doctype_name_state");
+  }
+
+  fn process_after_doctype_name_state(&mut self) -> Option<Token> {
+    todo!("process_after_doctype_name_state");
+  }
+
+  fn process_bogus_doctype_state(&mut self) -> Option<Token> {
+    todo!("process_bogus_doctype_state");
   }
 
   /* -------------------------------------------- */

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -645,12 +645,14 @@ impl<'a> Tokenizer<'a> {
         pattern.iter().map(|&b| b.to_ascii_lowercase()).collect::<Vec<_>>();
 
       if peeked == pattern {
-        self.stream.advance_by(pattern_len);
+        // for _ in 0..pattern.len() { self.stream.advance(); } のイメージ
+        self.stream.advance_by(pattern_len - 1);
         return true;
       }
     } else {
       if peeked == pattern {
-        self.stream.advance_by(pattern_len);
+        // for _ in 0..pattern.len() { self.stream.advance(); } のイメージ
+        self.stream.advance_by(pattern_len - 1);
         return true;
       }
     }

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -744,12 +744,10 @@ impl<'a> Tokenizer<'a> {
         self.stream.advance_by(pattern_len - 1);
         return true;
       }
-    } else {
-      if peeked == pattern {
-        // for _ in 0..pattern.len() { self.stream.advance(); } のイメージ
-        self.stream.advance_by(pattern_len - 1);
-        return true;
-      }
+    } else if peeked == pattern {
+      // for _ in 0..pattern.len() { self.stream.advance(); } のイメージ
+      self.stream.advance_by(pattern_len - 1);
+      return true;
     }
 
     false

--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -613,8 +613,6 @@ impl<'a> Tokenizer<'a> {
 
     let peeked = self.stream.slice_len(pattern_len);
 
-    trace!("-- read_if_match: {}", bytes_to_string(peeked));
-
     if ignore_case {
       let peeked =
         peeked.iter().map(|&b| b.to_ascii_lowercase()).collect::<Vec<_>>();

--- a/components/fast_html/src/tokenizer/state.rs
+++ b/components/fast_html/src/tokenizer/state.rs
@@ -16,6 +16,7 @@ pub enum State {
   AttributeValueUnQuoted,
   AfterAttributeValueQuoted,
 
+  MarkupDeclarationOpen,
   DOCTYPE,
   BeforeDOCTYPEName,
   DOCTYPEName,

--- a/components/fast_html/src/tokenizer/state.rs
+++ b/components/fast_html/src/tokenizer/state.rs
@@ -15,4 +15,10 @@ pub enum State {
   AttributeValueSingleQuoted,
   AttributeValueUnQuoted,
   AfterAttributeValueQuoted,
+
+  DOCTYPE,
+  BeforeDOCTYPEName,
+  DOCTYPEName,
+  AfterDOCTYPEName,
+  BogusDOCTYPE,
 }

--- a/components/fast_html/src/tokenizer/stream.rs
+++ b/components/fast_html/src/tokenizer/stream.rs
@@ -76,7 +76,7 @@ impl<'a, T> Stream<'a, T> {
     &self.data[from..min(self.data.len(), to)]
   }
 
-  pub fn slice_len(&self, from: usize, len: usize) -> &'a [T] {
-    self.slice_checked(from, self.idx + len)
+  pub fn slice_len(&self, len: usize) -> &'a [T] {
+    self.slice_checked(self.idx, self.idx + len)
   }
 }

--- a/components/fast_html/src/tokenizer/token.rs
+++ b/components/fast_html/src/tokenizer/token.rs
@@ -65,6 +65,13 @@ impl Token {
     Token::Text(EcoString::from(text))
   }
 
+  pub fn new_doctype_char_of(ch: char) -> Self {
+    Token::DOCTYPE {
+      name: Some(EcoString::from(ch)),
+      force_quirks: false,
+    }
+  }
+
   pub fn new_doctype_with_force_quirks() -> Self {
     Token::DOCTYPE {
       name: None,

--- a/components/fast_html/src/tokenizer/token.rs
+++ b/components/fast_html/src/tokenizer/token.rs
@@ -112,6 +112,16 @@ impl Token {
     }
   }
 
+  pub fn set_force_quirks(&mut self, value: bool) {
+    if let Token::DOCTYPE {
+      ref mut force_quirks,
+      ..
+    } = self
+    {
+      *force_quirks = value;
+    }
+  }
+
   /* checker ------------------------------------ */
 
   pub fn is_start_tag(&self) -> bool {

--- a/components/fast_html/src/tokenizer/token.rs
+++ b/components/fast_html/src/tokenizer/token.rs
@@ -4,13 +4,13 @@ use std::ops::DerefMut;
 use ecow::EcoString;
 use ecow::EcoVec;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Attribute {
   pub name: EcoString,
   pub value: EcoString,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Token {
   DOCTYPE {
     name: Option<EcoString>,

--- a/components/fast_html/src/tokenizer/token.rs
+++ b/components/fast_html/src/tokenizer/token.rs
@@ -65,6 +65,13 @@ impl Token {
     Token::Text(EcoString::from(text))
   }
 
+  pub fn new_doctype_with_force_quirks() -> Self {
+    Token::DOCTYPE {
+      name: None,
+      force_quirks: true,
+    }
+  }
+
   /* getter ------------------------------------- */
 
   pub fn tag_name(&self) -> &EcoString {

--- a/components/fast_html/tests/doctype.rs
+++ b/components/fast_html/tests/doctype.rs
@@ -1,0 +1,21 @@
+extern crate fast_html;
+
+use fast_html::tokenizer::token::Token;
+use fast_html::tokenizer::Tokenizer;
+
+use ecow::EcoString;
+
+#[test]
+fn html5_doctype() {
+  let html = r#"<!DOCTYPE html>"#;
+
+  let mut tokenizer = Tokenizer::new(html.as_bytes());
+  let actual = tokenizer.next_token();
+
+  let excepted = Token::DOCTYPE {
+    name: Some(EcoString::from("html")),
+    force_quirks: false,
+  };
+
+  assert_eq!(actual, excepted);
+}


### PR DESCRIPTION
`<!DOCTYPE html>`のような正常なHTML5のDOCTYPEを読めるようにする。