### PR TITLE
[fast_html] 完全な構造のHTMLを解析できるように

### DIFF
--- a/components/fast_html/src/debugger/mod.rs
+++ b/components/fast_html/src/debugger/mod.rs
@@ -24,7 +24,7 @@ pub fn get_document_from_html(html: &str) -> NodePtr {
   )));
 
   let tokenizer = Tokenizer::new(target);
-  let mut tree_builder = TreeBuilder::new(tokenizer, empty_document);
+  let tree_builder = TreeBuilder::new(tokenizer, empty_document);
 
   tree_builder.run()
 }

--- a/components/fast_html/src/tree_builder/insert_mode.rs
+++ b/components/fast_html/src/tree_builder/insert_mode.rs
@@ -1,9 +1,14 @@
 #[derive(Debug, Clone)]
 pub enum InsertMode {
   Initial,
+
   BeforeHtml,
+
   BeforeHead,
   InHead,
   AfterHead,
+
   InBody,
+  AfterBody,
+  AfterAfterBody,
 }

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -84,16 +84,15 @@ impl<'a> TreeBuilder<'a> {
   }
 
   pub fn run(&mut self) -> NodePtr {
-    while !self.should_stop {
+    loop {
       let token = self.tokenizer.next_token();
       debug!("{:?}", token);
 
-      if token.is_eof() {
-        self.stop_parsing();
-        continue;
-      }
-
       self.process(token);
+
+      if self.should_stop {
+        break;
+      }
     }
 
     self.flush_text_insertion();
@@ -146,7 +145,7 @@ impl<'a> TreeBuilder<'a> {
         warn!("Unexpected text: {}", text);
       }
       Token::EOF => {
-        todo!("unexpected: Token::EOF");
+        warn!("Unexpected EOF");
       }
     }
   }

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -109,6 +109,8 @@ impl<'a> TreeBuilder<'a> {
       InsertMode::InHead => self.handle_in_head_mode(token),
       InsertMode::AfterHead => self.handle_after_head_mode(token),
       InsertMode::InBody => self.handle_in_body_mode(token),
+      InsertMode::AfterBody => self.handle_after_body_mode(token),
+      InsertMode::AfterAfterBody => self.handle_after_after_body_mode(token),
     }
   }
 
@@ -1097,7 +1099,7 @@ impl<'a> TreeBuilder<'a> {
         self.unexpected(&token);
       }
 
-      unimplemented!("self.switch_to(InsertMode::AfterBody)");
+      self.switch_to(InsertMode::AfterBody);
       return;
     }
 
@@ -1114,8 +1116,8 @@ impl<'a> TreeBuilder<'a> {
         self.unexpected(&token);
       }
 
-      unimplemented!("self.switch_to(InsertMode::AfterBody)");
-      //return self.process(token);
+      self.switch_to(InsertMode::AfterBody);
+      return self.process(token);
     }
 
     if token.is_start_tag()
@@ -1597,5 +1599,13 @@ impl<'a> TreeBuilder<'a> {
     if token.is_end_tag() {
       any_other_end_tags(self, token)
     }
+  }
+
+  fn handle_after_body_mode(&mut self, token: Token) {
+    todo!("handle_after_body_mode");
+  }
+
+  fn handle_after_after_body_mode(&mut self, token: Token) {
+    todo!("handle_after_after_body_mode");
   }
 }

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1602,7 +1602,44 @@ impl<'a> TreeBuilder<'a> {
   }
 
   fn handle_after_body_mode(&mut self, token: Token) {
-    todo!("handle_after_body_mode");
+    if let Token::Text(ref str) = token {
+      if str.trim().is_empty() {
+        return self.handle_in_body_mode(token);
+      }
+    }
+
+    if let Token::Comment(text) = token {
+      let data = DOMNodeData::Comment(text);
+      let comment = TreeNode::new(DOMNode::new(data));
+      let first_open_element = self.open_elements.first().unwrap();
+      first_open_element.append_child(comment);
+      return;
+    }
+
+    if let Token::DOCTYPE { .. } = token {
+      self.unexpected(&token);
+      return;
+    }
+
+    if token.is_start_tag() && token.tag_name() == "html" {
+      return self.handle_in_body_mode(token);
+    }
+
+    if token.is_end_tag() && token.tag_name() == "html" {
+      // TODO: フラグメント解析アルゴリズムをサポートするか決める
+
+      self.switch_to(InsertMode::AfterAfterBody);
+      return;
+    }
+
+    if token.is_eof() {
+      self.stop_parsing();
+      return;
+    }
+
+    self.unexpected(&token);
+    self.switch_to(InsertMode::InBody);
+    self.process(token);
   }
 
   fn handle_after_after_body_mode(&mut self, token: Token) {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -84,15 +84,11 @@ impl<'a> TreeBuilder<'a> {
   }
 
   pub fn run(mut self) -> NodePtr {
-    loop {
+    while !self.should_stop {
       let token = self.tokenizer.next_token();
       debug!("{:?}", token);
 
       self.process(token);
-
-      if self.should_stop {
-        break;
-      }
     }
 
     self.flush_text_insertion();

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -83,7 +83,7 @@ impl<'a> TreeBuilder<'a> {
     }
   }
 
-  pub fn run(&mut self) -> NodePtr {
+  pub fn run(mut self) -> NodePtr {
     loop {
       let token = self.tokenizer.next_token();
       debug!("{:?}", token);
@@ -97,7 +97,7 @@ impl<'a> TreeBuilder<'a> {
 
     self.flush_text_insertion();
 
-    self.document.clone()
+    self.document
   }
 
   fn process(&mut self, token: Token) {

--- a/components/fast_html/tests/document.rs
+++ b/components/fast_html/tests/document.rs
@@ -1,0 +1,66 @@
+extern crate fast_html;
+
+use fast_html::debugger::*;
+
+use assert_json_diff::*;
+use serde_json::json;
+
+#[test]
+fn document_missing_head() {
+  let html = r#"<!DOCTYPE html>
+  <html>
+  <body>
+    <h1>heading</h1>
+    <p>paragraph</p>
+  </body>
+  </html>"#;
+
+  let expected = json!(
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "tag": "head",
+              "type": "element"
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "heading"
+                    }
+                  ],
+                  "tag": "h1",
+                  "type": "element"
+                },
+                {
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "paragraph"
+                    }
+                  ],
+                  "tag": "p",
+                  "type": "element"
+                }
+              ],
+              "tag": "body",
+              "type": "element"
+            }
+          ],
+          "tag": "html",
+          "type": "element"
+        }
+      ],
+      "type": "document"
+    }
+  );
+
+  let document = get_document_from_html(html);
+  let actual = dom_to_json(&document);
+
+  assert_json_eq!(actual, expected);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
 use std::env;
 
-const TARGET_HTML: &str =
-  r#"<a href="https://example.com" target="_blank">sample link</a>"#;
+const TARGET_HTML: &str = r#"<!DOCTYPE html>
+<html>
+<body>
+  <h1>heading</h1>
+  <p>paragraph</p>
+</body>
+</html>"#;
 
 fn run_html() {
   let document = html::debugger::get_document_from_html(TARGET_HTML);
@@ -10,7 +15,7 @@ fn run_html() {
 
   println!("-------------------");
 
-  let json = html::debugger::dom_in_body_to_json(&document);
+  let json = html::debugger::dom_to_json(&document);
 
   println!("{}", json);
 }
@@ -22,7 +27,7 @@ fn run_fast_html() {
 
   println!("-------------------");
 
-  let json = fast_html::debugger::dom_body_to_json_string(&document);
+  let json = fast_html::debugger::dom_to_json_string(&document);
   println!("{}", json);
 }
 


### PR DESCRIPTION
`AfterBody`・`AfterAfterBody`挿入モードが未実装のため、次のような完全な構造のHTMLが解析できなかった。

```html
<!DOCTYPE html>
<html>
<body>
  <h1>heading</h1>
  <p>paragraph</p>
</body>
</html>
```

なお、TreeBuilderがEOFトークンを適切に対処することなく問答無用で解析終了してしまっていたため、そこも修正。
EOFトークンの処理分、実行速度は落ちてしまったが仕方ない…

<img width="653" alt="スクリーンショット 2024-01-21 10 10 57" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/8d5a4a5a-a34b-4ad6-9b33-57e2daf52ced">
<img width="653" alt="スクリーンショット 2024-01-21 10 10 50" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/6607f2db-9167-4e36-84fb-4b3f7870a673">
<img width="653" alt="スクリーンショット 2024-01-21 10 10 41" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/9608d928-bf1c-4411-8bef-073696d01e06">
