### PR TITLE
HTML Parser: ルビ関連要素に対応

### DIFF
--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1610,7 +1610,16 @@ impl<'a> TreeBuilder<'a> {
     }
 
     if token.is_start_tag() && token.match_tag_name_in(&["rp", "rt"]) {
-      todo!("process_in_body: rp/rt start tag");
+      if self.open_elements.has_element_name_in_scope("ruby") {
+        self.generate_implied_end_tags("rtc");
+      }
+
+      if !self.current_node().as_element().match_tag_name_in(&["rtc", "ruby"]) {
+        self.unexpected(&token);
+      }
+
+      self.insert_html_element(token);
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "math" {

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1083,7 +1083,16 @@ impl<T: Tokenizing> TreeBuilder<T> {
     }
 
     if token.is_start_tag() && token.match_tag_name_in(&["rp", "rt"]) {
-      todo!("process_in_body: rp/rt start tag");
+      if self.open_elements.has_element_name_in_scope("ruby") {
+        self.generate_implied_end_tags("rtc");
+      }
+
+      if !self.current_node().as_element().match_tag_name_in(&["rtc", "ruby"]) {
+        self.unexpected(&token);
+      }
+
+      self.insert_html_element(token);
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "math" {

--- a/example/supported-tags.html
+++ b/example/supported-tags.html
@@ -77,6 +77,35 @@
             SI      RESPI
                     RER       - Apollinaire
         </pre>
+        <p>
+          A <dfn id="def-validator">validator</dfn> is a program that checks for
+          syntax errors in code or documents.
+        </p>
+        <p>
+          In HTML 5, what was previously called
+          <em>block-level</em> content is now called <em>flow</em> content.
+        </p>
+        <p>
+          The Latin phrase <i lang="la">Veni, vidi, vici</i> is often mentioned
+          in music, art, and literature.
+        </p>
+        <p>
+          Please press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> to
+          re-render an MDN page.
+        </p>
+        <p>
+          Most <mark>salamander</mark>s are nocturnal, and hunt for insects,
+          worms, and other small creatures.
+        </p>
+        <p>
+          According to Mozilla's website,
+          <q cite="https://example.com">
+            Firefox 1.0 was released in 2004 and became a big success.
+          </q>
+        </p>
+        <ruby>
+          漢 <rp>(</rp><rt>Kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
+        </ruby>
       </section>
       <article class="forecast">
         <h1>Weather forecast for Seattle</h1>
@@ -105,6 +134,21 @@
             composition of substances) and <b class="term">physics</b> (the
             study of the nature and properties of matter and energy).
           </p>
+          <p>
+            O’er all the hilltops<br />
+            Is quiet now,<br />
+            In all the treetops<br />
+            Hearest thou<br />
+            Hardly a breath;<br />
+            The birds are asleep in the trees:<br />
+            Wait, soon like these<br />
+            Thou too shalt rest.
+          </p>
+          <p>
+            The function <code>selectAll()</code> highlights all the text in the
+            input field so the user can, for example, copy or delete the text.
+          </p>
+
           <dl>
             <dt>Beast of Bodmin</dt>
             <dd>A large feline inhabiting Bodmin Moor.</dd>
@@ -124,6 +168,19 @@
                 <li>Feta</li>
               </ul>
             </li>
+          </ul>
+          <ul>
+            <li><bdi class="name">اَلأَعْشَى</bdi> - 1st place</li>
+            <li><bdi class="name">Jerry Cruncher</bdi> - 2nd place</li>
+          </ul>
+          <div>
+            <p>This text will go left to right.</p>
+            <p><bdo dir="rtl">This text will go right to left.</bdo></p>
+          </div>
+          <ul>
+            <li><data value="398">Mini Ketchup</data></li>
+            <li><data value="399">Jumbo Ketchup</data></li>
+            <li><data value="400">Mega Jumbo Ketchup</data></li>
           </ul>
         </article>
         <article class="day-forecast">

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,9 @@ const TARGET_HTML: &str = r#"<!DOCTYPE html>
   <title>document title</title>
 </head>
 <body>
-<p>
-  The two most popular science courses offered by the school are <b class="term">chemistry</b> (the study of chemicals
-  and the composition of substances) and <b class="term">physics</b> (the study of the nature and properties of matter
-  and energy).
-</p>
+<ruby>
+  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
+</ruby>
 </body>
 </html>"#;
 


### PR DESCRIPTION
次のようなHTMLを解析できるように、`rp`・`rt`タグへの対応を追加

```html
<ruby>
  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
</ruby>
```