### PR TITLE
HTML Parser: audio関連タグに対応

### DIFF
--- a/components/fast_html/src/tokenizer/mod.rs
+++ b/components/fast_html/src/tokenizer/mod.rs
@@ -335,7 +335,7 @@ impl<'a> Tokenizer<'a> {
         self.reconsume_in(State::AfterAttributeName);
       }
       b'/' | b'>' => {
-        self.switch_to(State::AfterAttributeName);
+        self.reconsume_in(State::AfterAttributeName);
       }
       b'=' => {
         self.switch_to(State::BeforeAttributeValue);

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1557,7 +1557,10 @@ impl<'a> TreeBuilder<'a> {
     if token.is_start_tag()
       && token.match_tag_name_in(&["param", "source", "track"])
     {
-      todo!("process_in_body: param/source/track start tag");
+      token.acknowledge_self_closing_if_set();
+      self.insert_html_element(token);
+      self.open_elements.pop();
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "hr" {

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1030,7 +1030,10 @@ impl<T: Tokenizing> TreeBuilder<T> {
     if token.is_start_tag()
       && token.match_tag_name_in(&["param", "source", "track"])
     {
-      todo!("process_in_body: param/source/track start tag");
+      token.acknowledge_self_closing_if_set();
+      self.insert_html_element(token);
+      self.open_elements.pop();
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "hr" {

--- a/example/supported-tags.html
+++ b/example/supported-tags.html
@@ -30,7 +30,7 @@
   <body>
     <header>
       <h1>Beagles</h1>
-      <time>08.12.2014</time>
+      <time datetime="2018-07-07">July 7</time>
     </header>
     <div class="news">
       <a href="news.html"
@@ -77,6 +77,12 @@
             SI      RESPI
                     RER       - Apollinaire
         </pre>
+        <pre>
+          <samp><span class="prompt">mike@interwebz:~$</span> <kbd>md5 -s "Hello world"</kbd>
+          MD5 ("Hello world") = 3e25960a79dbc69b674cd4ec67a72c62
+          
+          <span class="prompt">mike@interwebz:~$</span> <span class="cursor">█</span></samp></pre>
+
         <p>
           A <dfn id="def-validator">validator</dfn> is a program that checks for
           syntax errors in code or documents.
@@ -86,8 +92,25 @@
           <em>block-level</em> content is now called <em>flow</em> content.
         </p>
         <p>
+          ... the most important rule, the rule you can never forget, no matter
+          how much he cries, no matter how much he begs:
+          <strong>never feed him after midnight</strong>.
+        </p>
+        <p>
+          Almost every developer's favorite molecule is
+          C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub>, also known as
+          "caffeine."
+        </p>
+        <p>Robert a présenté son rapport à M<sup>lle</sup> Bernard.</p>
+        <p>
           The Latin phrase <i lang="la">Veni, vidi, vici</i> is often mentioned
           in music, art, and literature.
+        </p>
+        <p>
+          <small
+            >The content is licensed under a Creative Commons
+            Attribution-ShareAlike 2.5 Generic License.</small
+          >
         </p>
         <p>
           Please press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd> to
@@ -98,6 +121,11 @@
           worms, and other small creatures.
         </p>
         <p>
+          This paragraph includes a <u class="spelling">wrnogly</u> spelled
+          word.
+        </p>
+
+        <p>
           According to Mozilla's website,
           <q cite="https://example.com">
             Firefox 1.0 was released in 2004 and became a big success.
@@ -106,6 +134,11 @@
         <ruby>
           漢 <rp>(</rp><rt>Kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
         </ruby>
+        <p>
+          <s
+            >There will be a few tickets available at the box office tonight.</s
+          >
+        </p>
       </section>
       <article class="forecast">
         <h1>Weather forecast for Seattle</h1>
@@ -145,8 +178,17 @@
             Thou too shalt rest.
           </p>
           <p>
+            Fernstraßen<wbr />bau<wbr />privat<wbr />finanzierungs<wbr />gesetz
+          </p>
+
+          <p>
             The function <code>selectAll()</code> highlights all the text in the
             input field so the user can, for example, copy or delete the text.
+          </p>
+          <p>
+            The volume of a box is <var>l</var> × <var>w</var> × <var>h</var>,
+            where <var>l</var> represents the length, <var>w</var> the width and
+            <var>h</var> the height of the box.
           </p>
 
           <dl>
@@ -199,6 +241,30 @@
             />
             <figcaption>An elephant at sunset</figcaption>
           </figure>
+          <map name="primary">
+            <area
+              shape="circle"
+              coords="75,75,75"
+              href="left.html"
+              alt="Click to go Left"
+            />
+            <area
+              shape="circle"
+              coords="275,75,75"
+              href="right.html"
+              alt="Click to go Right"
+            />
+          </map>
+          <img
+            usemap="#primary"
+            src="https://via.placeholder.com/350x150"
+            alt="350 x 150 pic"
+          />
+          <audio controls>
+            <source src="foo.opus" type="audio/ogg; codecs=opus" />
+            <source src="foo.ogg" type="audio/ogg; codecs=vorbis" />
+            <source src="foo.mp3" type="audio/mpeg" />
+          </audio>
         </article>
       </article>
     </main>

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,11 @@ const TARGET_HTML: &str = r#"<!DOCTYPE html>
   <title>document title</title>
 </head>
 <body>
-<ruby>
-  漢 <rp>(</rp><rt>Kan</rt><rp>)</rp> 字 <rp>(</rp><rt>ji</rt><rp>)</rp>
-</ruby>
+<audio controls>
+  <source src="foo.opus" type="audio/ogg; codecs=opus" />
+  <source src="foo.ogg" type="audio/ogg; codecs=vorbis" />
+  <source src="foo.mp3" type="audio/mpeg" />
+</audio>
 </body>
 </html>"#;
 


### PR DESCRIPTION
こんな感じのHTMLが読めるようになった。

```html
<audio controls>
  <source src="foo.opus" type="audio/ogg; codecs=opus" />
  <source src="foo.ogg" type="audio/ogg; codecs=vorbis" />
  <source src="foo.mp3" type="audio/mpeg" />
</audio>
```

`controls>`部分など、値のない属性を検出した場合、Tokenizerが無限ループになってしまう問題も解消した。
