### PR TITLE
HTML Parser: "applet", "marquee", "object"タグに対応

### DIFF
--- a/components/fast_html/src/tree_builder/list_of_active_formatting_elements.rs
+++ b/components/fast_html/src/tree_builder/list_of_active_formatting_elements.rs
@@ -88,4 +88,15 @@ impl ListOfActiveFormattingElements {
   pub fn add_marker(&mut self) {
     self.entries.push(Entry::Marker);
   }
+
+  pub fn clear_up_to_last_marker(&mut self) {
+    let index = self
+      .iter()
+      .rposition(|entry| match entry {
+        Entry::Marker => true,
+        Entry::Element(_) => false,
+      })
+      .unwrap_or_else(|| panic!("Unable to find marker"));
+    self.entries.truncate(index);
+  }
 }

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1522,7 +1522,21 @@ impl<'a> TreeBuilder<'a> {
     if token.is_end_tag()
       && token.match_tag_name_in(&["applet", "marquee", "object"])
     {
-      todo!("process_in_body: applet/marquee/object end tag");
+      if !self.open_elements.has_element_name_in_scope(&token.tag_name()) {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != *token.tag_name() {
+        self.unexpected(&token);
+      }
+
+      self.open_elements.pop_until(token.tag_name());
+      self.active_formatting_elements.clear_up_to_last_marker();
+
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "table" {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1512,7 +1512,11 @@ impl<'a> TreeBuilder<'a> {
     if token.is_start_tag()
       && token.match_tag_name_in(&["applet", "marquee", "object"])
     {
-      todo!("process_in_body: applet/marquee/object start tag");
+      self.reconstruct_active_formatting_elements();
+      self.insert_html_element(token);
+      self.active_formatting_elements.add_marker();
+      self.frameset_ok = false;
+      return;
     }
 
     if token.is_end_tag()

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1522,7 +1522,7 @@ impl<'a> TreeBuilder<'a> {
     if token.is_end_tag()
       && token.match_tag_name_in(&["applet", "marquee", "object"])
     {
-      if !self.open_elements.has_element_name_in_scope(&token.tag_name()) {
+      if !self.open_elements.has_element_name_in_scope(token.tag_name()) {
         self.unexpected(&token);
         return;
       }

--- a/components/html/src/tree_builder/list_of_active_formatting_elements.rs
+++ b/components/html/src/tree_builder/list_of_active_formatting_elements.rs
@@ -88,4 +88,15 @@ impl ListOfActiveFormattingElements {
   pub fn add_marker(&mut self) {
     self.entries.push(Entry::Marker);
   }
+
+  pub fn clear_up_to_last_marker(&mut self) {
+    let index = self
+      .iter()
+      .rposition(|entry| match entry {
+        Entry::Marker => true,
+        Entry::Element(_) => false,
+      })
+      .unwrap_or_else(|| panic!("Unable to find marker"));
+    self.entries.truncate(index);
+  }
 }

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -985,7 +985,11 @@ impl<T: Tokenizing> TreeBuilder<T> {
     if token.is_start_tag()
       && token.match_tag_name_in(&["applet", "marquee", "object"])
     {
-      todo!("process_in_body: applet/marquee/object start tag");
+      self.reconstruct_active_formatting_elements();
+      self.insert_html_element(token);
+      self.active_formatting_elements.add_marker();
+      self.frameset_ok = false;
+      return;
     }
 
     if token.is_end_tag()

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -995,7 +995,17 @@ impl<T: Tokenizing> TreeBuilder<T> {
     if token.is_end_tag()
       && token.match_tag_name_in(&["applet", "marquee", "object"])
     {
-      todo!("process_in_body: applet/marquee/object end tag");
+      if !self.open_elements.has_element_name_in_scope(&token.tag_name()) {
+        self.unexpected(&token);
+        return;
+      }
+      self.generate_implied_end_tags("");
+      if self.current_node().as_element().tag_name() != *token.tag_name() {
+        self.unexpected(&token);
+      }
+      self.open_elements.pop_until(token.tag_name());
+      self.active_formatting_elements.clear_up_to_last_marker();
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "table" {

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -995,7 +995,7 @@ impl<T: Tokenizing> TreeBuilder<T> {
     if token.is_end_tag()
       && token.match_tag_name_in(&["applet", "marquee", "object"])
     {
-      if !self.open_elements.has_element_name_in_scope(&token.tag_name()) {
+      if !self.open_elements.has_element_name_in_scope(token.tag_name()) {
         self.unexpected(&token);
         return;
       }

--- a/example/supported-tags.html
+++ b/example/supported-tags.html
@@ -291,6 +291,12 @@
             height="480"
             title="Title of my video"
           />
+          <object
+            type="application/pdf"
+            data="/media/examples/In-CC0.pdf"
+            width="250"
+            height="200"
+          ></object>
         </article>
       </article>
     </main>

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,13 +6,7 @@ const TARGET_HTML: &str = r#"<!DOCTYPE html>
   <title>document title</title>
 </head>
 <body>
-<iframe
-  src="https://example.org"
-  title="iframe Example 1"
-  width="400"
-  height="300">
-</iframe>
-
+<object type="application/pdf" data="/media/examples/In-CC0.pdf" width="250" height="200"></object>
 </body>
 </html>"#;
 


### PR DESCRIPTION
こんな感じのHTMLが読めるようにする。

```html
<object type="application/pdf" data="/media/examples/In-CC0.pdf" width="250" height="200"></object>
```