### PR TITLE
HTML Parser: tableをサポート

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ RUST_LOG=trace cargo run -- html
 - 古いDOCTYPE
 - 文字参照
 - コメント
-- scriptタグ
+- canvas、script、noscriptタグ
 - styleタグ
 - framesetタグ
 - templateタグ
 - searchタグ + form関連タグ
 - SVG関連タグ
+- MathML関連タグ
 
 ## WIP: CSS Parser
 

--- a/components/fast_html/src/tree_builder/insert_mode.rs
+++ b/components/fast_html/src/tree_builder/insert_mode.rs
@@ -13,4 +13,15 @@ pub enum InsertMode {
   AfterAfterBody,
 
   Text,
+
+  InTable,
+  InTableText,
+  InTableBody,
+  InRow,
+  InCell,
+  InCaption,
+  InColumnGroup,
+
+  InSelect,
+  InSelectInTable,
 }

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1556,9 +1556,9 @@ impl<'a> TreeBuilder<'a> {
 
       self.insert_html_element(token);
       self.frameset_ok = false;
-      unimplemented!("self.switch_to(InsertMode::InTable)");
+      self.switch_to(InsertMode::InTable);
 
-      //return;
+      return;
     }
 
     if token.is_end_tag() && token.tag_name() == "br" {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1994,7 +1994,53 @@ impl<'a> TreeBuilder<'a> {
   }
 
   fn handle_in_table_body_mode(&mut self, token: Token) {
-    todo!("handle_in_table_body_mode");
+    if token.is_start_tag() && token.tag_name() == "tr" {
+      self.open_elements.clear_back_to_table_body_context();
+      self.insert_html_element(token);
+      self.switch_to(InsertMode::InRow);
+      return;
+    }
+
+    if token.is_start_tag() && token.match_tag_name_in(&["th", "td"]) {
+      todo!("process_in_table_body: th/td start tag");
+    }
+
+    if token.is_end_tag()
+      && token.match_tag_name_in(&["tbody", "tfoot", "thead"])
+    {
+      if !self.open_elements.has_element_name_in_table_scope(&token.tag_name())
+      {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.open_elements.clear_back_to_table_body_context();
+      self.open_elements.pop();
+      self.switch_to(InsertMode::InTable);
+      return;
+    }
+
+    if token.is_start_tag()
+      && token.match_tag_name_in(&[
+        "caption", "col", "colgroup", "tbody", "tfoot", "thead",
+      ])
+    {
+      todo!("process_in_table_body: caption/col/colgroup/tbody/tfoot/thead start tag");
+    }
+
+    if token.is_end_tag() && token.tag_name() == "table" {
+      todo!("process_in_table_body: table end tag");
+    }
+
+    if token.is_end_tag()
+      && token.match_tag_name_in(&[
+        "body", "caption", "col", "colgroup", "html", "td", "th", "tr",
+      ])
+    {
+      todo!("process_in_table_body: body end tag");
+    }
+
+    self.handle_in_table_mode(token)
   }
 
   fn handle_in_row_mode(&mut self, token: Token) {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -2044,7 +2044,53 @@ impl<'a> TreeBuilder<'a> {
   }
 
   fn handle_in_row_mode(&mut self, token: Token) {
-    todo!("handle_in_row_mode");
+    if token.is_start_tag() && token.match_tag_name_in(&["th", "td"]) {
+      self.open_elements.clear_back_to_table_row_context();
+      self.insert_html_element(token);
+      self.switch_to(InsertMode::InCell);
+      self.active_formatting_elements.add_marker();
+      return;
+    }
+
+    if token.is_end_tag() && token.tag_name() == "tr" {
+      if !self.open_elements.has_element_name_in_table_scope("tr") {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.open_elements.clear_back_to_table_row_context();
+      self.open_elements.pop();
+      self.switch_to(InsertMode::InTableBody);
+      return;
+    }
+
+    if token.is_start_tag()
+      && token.match_tag_name_in(&[
+        "caption", "col", "colgroup", "tbody", "tfoot", "thead", "tr",
+      ])
+    {
+      todo!("process_in_row: caption/col/colgroup/tbody/tfoot/thead start tag");
+    }
+
+    if token.is_end_tag() && token.tag_name() == "table" {
+      todo!("process_in_row: table end tag");
+    }
+
+    if token.is_end_tag()
+      && token.match_tag_name_in(&["tbody", "tfoot", "thead"])
+    {
+      todo!("process_in_row: tbody/tfoot/thead end tag");
+    }
+
+    if token.is_end_tag()
+      && token.match_tag_name_in(&[
+        "body", "caption", "col", "colgroup", "html", "td", "th",
+      ])
+    {
+      todo!("process_in_row: body/caption/col/colgroup/html/td/th end tag");
+    }
+
+    self.handle_in_table_mode(token)
   }
 
   fn handle_in_cell_mode(&mut self, token: Token) {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -2094,7 +2094,47 @@ impl<'a> TreeBuilder<'a> {
   }
 
   fn handle_in_cell_mode(&mut self, token: Token) {
-    todo!("handle_in_cell_mode");
+    if token.is_end_tag() && token.match_tag_name_in(&["td", "th"]) {
+      if !self.open_elements.has_element_name_in_table_scope(&token.tag_name())
+      {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != *token.tag_name() {
+        warn!("Expected current node to have same tag name as token");
+      }
+      self.open_elements.pop_until(token.tag_name());
+      self.active_formatting_elements.clear_up_to_last_marker();
+      self.switch_to(InsertMode::InRow);
+      return;
+    }
+
+    if token.is_start_tag()
+      && token.match_tag_name_in(&[
+        "caption", "col", "colgroup", "tbody", "td", "tfoot", "th", "thead",
+        "tr",
+      ])
+    {
+      todo!("process_in_cell: caption/col/colgroup/tbody/td/tfoot/th/thead/tr start tag");
+    }
+
+    if token.is_end_tag()
+      && token
+        .match_tag_name_in(&["body", "caption", "col", "colgroup", "html"])
+    {
+      todo!("process_in_cell: body/caption/col/colgroup/html end tag");
+    }
+
+    if token.is_end_tag()
+      && token.match_tag_name_in(&["table", "tbody", "tfoot", "thead", "tr"])
+    {
+      todo!("process_in_cell: table/tbody/tfoot/thead/tr end tag");
+    }
+
+    self.handle_in_body_mode(token)
   }
 
   fn handle_in_column_group_mode(&mut self, token: Token) {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -2008,8 +2008,7 @@ impl<'a> TreeBuilder<'a> {
     if token.is_end_tag()
       && token.match_tag_name_in(&["tbody", "tfoot", "thead"])
     {
-      if !self.open_elements.has_element_name_in_table_scope(&token.tag_name())
-      {
+      if !self.open_elements.has_element_name_in_table_scope(token.tag_name()) {
         self.unexpected(&token);
         return;
       }
@@ -2095,8 +2094,7 @@ impl<'a> TreeBuilder<'a> {
 
   fn handle_in_cell_mode(&mut self, token: Token) {
     if token.is_end_tag() && token.match_tag_name_in(&["td", "th"]) {
-      if !self.open_elements.has_element_name_in_table_scope(&token.tag_name())
-      {
+      if !self.open_elements.has_element_name_in_table_scope(token.tag_name()) {
         self.unexpected(&token);
         return;
       }
@@ -2137,19 +2135,19 @@ impl<'a> TreeBuilder<'a> {
     self.handle_in_body_mode(token)
   }
 
-  fn handle_in_column_group_mode(&mut self, token: Token) {
+  fn handle_in_column_group_mode(&mut self, _token: Token) {
     todo!("handle_in_column_group_mode");
   }
 
-  fn handle_in_caption_mode(&mut self, token: Token) {
+  fn handle_in_caption_mode(&mut self, _token: Token) {
     todo!("handle_in_caption_mode");
   }
 
-  fn handle_in_select_mode(&mut self, token: Token) {
+  fn handle_in_select_mode(&mut self, _token: Token) {
     todo!("handle_in_select_mode");
   }
 
-  fn handle_in_select_in_table_mode(&mut self, token: Token) {
+  fn handle_in_select_in_table_mode(&mut self, _token: Token) {
     todo!("handle_in_select_in_table_mode");
   }
 

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -114,6 +114,15 @@ impl<'a> TreeBuilder<'a> {
       InsertMode::InBody => self.handle_in_body_mode(token),
       InsertMode::AfterBody => self.handle_after_body_mode(token),
       InsertMode::AfterAfterBody => self.handle_after_after_body_mode(token),
+      InsertMode::InTable => self.handle_in_table_mode(token),
+      InsertMode::InTableText => self.handle_in_table_text_mode(token),
+      InsertMode::InTableBody => self.handle_in_table_body_mode(token),
+      InsertMode::InRow => self.handle_in_row_mode(token),
+      InsertMode::InCell => self.handle_in_cell_mode(token),
+      InsertMode::InColumnGroup => self.handle_in_column_group_mode(token),
+      InsertMode::InCaption => self.handle_in_caption_mode(token),
+      InsertMode::InSelect => self.handle_in_select_mode(token),
+      InsertMode::InSelectInTable => self.handle_in_select_in_table_mode(token),
       InsertMode::Text => self.handle_text_mode(token),
     }
   }
@@ -1747,6 +1756,42 @@ impl<'a> TreeBuilder<'a> {
     self.unexpected(&token);
     self.switch_to(InsertMode::InBody);
     self.process(token);
+  }
+
+  fn handle_in_table_mode(&mut self, token: Token) {
+    todo!("handle_in_table_mode");
+  }
+
+  fn handle_in_table_text_mode(&mut self, token: Token) {
+    todo!("handle_in_table_text_mode");
+  }
+
+  fn handle_in_table_body_mode(&mut self, token: Token) {
+    todo!("handle_in_table_body_mode");
+  }
+
+  fn handle_in_row_mode(&mut self, token: Token) {
+    todo!("handle_in_row_mode");
+  }
+
+  fn handle_in_cell_mode(&mut self, token: Token) {
+    todo!("handle_in_cell_mode");
+  }
+
+  fn handle_in_column_group_mode(&mut self, token: Token) {
+    todo!("handle_in_column_group_mode");
+  }
+
+  fn handle_in_caption_mode(&mut self, token: Token) {
+    todo!("handle_in_caption_mode");
+  }
+
+  fn handle_in_select_mode(&mut self, token: Token) {
+    todo!("handle_in_select_mode");
+  }
+
+  fn handle_in_select_in_table_mode(&mut self, token: Token) {
+    todo!("handle_in_select_in_table_mode");
   }
 
   fn handle_text_mode(&mut self, token: Token) {

--- a/components/fast_html/src/tree_builder/stack_of_open_elements.rs
+++ b/components/fast_html/src/tree_builder/stack_of_open_elements.rs
@@ -152,6 +152,14 @@ impl StackOfOpenElements {
     self.has_element_name_in_specific_scope(tag_name, list)
   }
 
+  pub fn has_element_name_in_table_scope(&self, tag_name: &str) -> bool {
+    let mut list = EcoVec::from(SCOPE_BASE_LIST);
+    list.push("html");
+    list.push("table");
+    list.push("template");
+    self.has_element_name_in_specific_scope(tag_name, list)
+  }
+
   /* pop ---------------------------------------- */
 
   // tag_nameがpopされるまでpopする

--- a/components/html/src/tree_builder/insert_mode.rs
+++ b/components/html/src/tree_builder/insert_mode.rs
@@ -17,4 +17,9 @@ pub enum InsertMode {
   InTableBody,
   InRow,
   InCell,
+  InCaption,
+  InColumnGroup,
+
+  InSelect,
+  InSelectInTable,
 }

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1432,7 +1432,21 @@ impl<T: Tokenizing> TreeBuilder<T> {
 
   fn process_in_cell(&mut self, token: Token) {
     if token.is_end_tag() && token.match_tag_name_in(&["td", "th"]) {
-      todo!("process_in_cell: td/th end tag");
+      if !self.open_elements.has_element_name_in_table_scope(&token.tag_name())
+      {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != *token.tag_name() {
+        warn!("Expected current node to have same tag name as token");
+      }
+      self.open_elements.pop_until(token.tag_name());
+      self.active_formatting_elements.clear_up_to_last_marker();
+      self.switch_to(InsertMode::InRow);
+      return;
     }
 
     if token.is_start_tag()

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1337,8 +1337,7 @@ impl<T: Tokenizing> TreeBuilder<T> {
     if token.is_end_tag()
       && token.match_tag_name_in(&["tbody", "tfoot", "thead"])
     {
-      if !self.open_elements.has_element_name_in_table_scope(&token.tag_name())
-      {
+      if !self.open_elements.has_element_name_in_table_scope(token.tag_name()) {
         self.unexpected(&token);
         return;
       }
@@ -1459,8 +1458,7 @@ impl<T: Tokenizing> TreeBuilder<T> {
 
   fn process_in_cell(&mut self, token: Token) {
     if token.is_end_tag() && token.match_tag_name_in(&["td", "th"]) {
-      if !self.open_elements.has_element_name_in_table_scope(&token.tag_name())
-      {
+      if !self.open_elements.has_element_name_in_table_scope(token.tag_name()) {
         self.unexpected(&token);
         return;
       }
@@ -1501,19 +1499,19 @@ impl<T: Tokenizing> TreeBuilder<T> {
     self.process_in_body(token)
   }
 
-  fn process_in_column_group(&mut self, token: Token) {
+  fn process_in_column_group(&mut self, _token: Token) {
     todo!("process_in_column_group");
   }
 
-  fn process_in_caption(&mut self, token: Token) {
+  fn process_in_caption(&mut self, _token: Token) {
     todo!("process_in_caption");
   }
 
-  fn process_in_select(&mut self, token: Token) {
+  fn process_in_select(&mut self, _token: Token) {
     todo!("process_in_select");
   }
 
-  fn process_in_select_in_table(&mut self, token: Token) {
+  fn process_in_select_in_table(&mut self, _token: Token) {
     todo!("process_in_select_in_table");
   }
 

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1327,7 +1327,16 @@ impl<T: Tokenizing> TreeBuilder<T> {
     if token.is_end_tag()
       && token.match_tag_name_in(&["tbody", "tfoot", "thead"])
     {
-      todo!("process_in_table_body: tbody/tfoot/thead end tag");
+      if !self.open_elements.has_element_name_in_table_scope(&token.tag_name())
+      {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.open_elements.clear_back_to_table_body_context();
+      self.open_elements.pop();
+      self.switch_to(InsertMode::InTable);
+      return;
     }
 
     if token.is_start_tag()

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1398,7 +1398,15 @@ impl<T: Tokenizing> TreeBuilder<T> {
     }
 
     if token.is_end_tag() && token.tag_name() == "tr" {
-      todo!("process_in_row: tr end tag");
+      if !self.open_elements.has_element_name_in_table_scope("tr") {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.open_elements.clear_back_to_table_row_context();
+      self.open_elements.pop();
+      self.switch_to(InsertMode::InTableBody);
+      return;
     }
 
     if token.is_start_tag()

--- a/components/html/src/tree_builder/stack_of_open_elements.rs
+++ b/components/html/src/tree_builder/stack_of_open_elements.rs
@@ -152,6 +152,14 @@ impl StackOfOpenElements {
     self.has_element_name_in_specific_scope(tag_name, list)
   }
 
+  pub fn has_element_name_in_table_scope(&self, tag_name: &str) -> bool {
+    let mut list = EcoVec::from(SCOPE_BASE_LIST);
+    list.push("html");
+    list.push("table");
+    list.push("template");
+    self.has_element_name_in_specific_scope(tag_name, list)
+  }
+
   /* pop ---------------------------------------- */
 
   // tag_nameがpopされるまでpopする

--- a/example/supported-tags.html
+++ b/example/supported-tags.html
@@ -59,6 +59,19 @@
         height="300"
       >
       </iframe>
+      <table>
+        <thead>
+          <tr>
+            <th colspan="2">The table header</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>The table body</td>
+            <td>with two columns</td>
+          </tr>
+        </tbody>
+      </table>
       <section>
         <h2>Introduction</h2>
         <p>
@@ -197,6 +210,12 @@
             where <var>l</var> represents the length, <var>w</var> the width and
             <var>h</var> the height of the box.
           </p>
+          <del>
+            <p>“I apologize for the delay.”</p>
+          </del>
+          <ins cite="../howtobeawizard.html" datetime="2018-05">
+            <p>“A wizard is never late …”</p>
+          </ins>
 
           <dl>
             <dt>Beast of Bodmin</dt>
@@ -267,6 +286,11 @@
             src="https://via.placeholder.com/350x150"
             alt="350 x 150 pic"
           />
+          <picture>
+            <source srcset="mdn-logo-wide.png" media="(min-width: 600px)" />
+            <img src="mdn-logo-narrow.png" alt="MDN" />
+          </picture>
+
           <audio controls>
             <source src="foo.opus" type="audio/ogg; codecs=opus" />
             <source src="foo.ogg" type="audio/ogg; codecs=vorbis" />

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,20 @@ const TARGET_HTML: &str = r#"<!DOCTYPE html>
   <title>document title</title>
 </head>
 <body>
-<object type="application/pdf" data="/media/examples/In-CC0.pdf" width="250" height="200"></object>
+<table>
+  <thead>
+    <tr>
+      <th colspan="2">The table header</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>The table body</td>
+      <td>with two columns</td>
+    </tr>
+  </tbody>
+</table>
+
 </body>
 </html>"#;
 


### PR DESCRIPTION
こんな感じのHTMLが読めるように：

```html
<table>
  <thead>
    <tr>
      <th colspan="2">The table header</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>The table body</td>
      <td>with two columns</td>
    </tr>
  </tbody>
</table>
```