### PR TITLE
HTML Parser: table captionとtbodyの省略に対応

### DIFF
--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -2231,7 +2231,7 @@ impl<'a> TreeBuilder<'a> {
       return;
     }
 
-    return self.handle_in_body_mode(token);
+    self.handle_in_body_mode(token)
   }
 
   fn handle_in_select_mode(&mut self, _token: Token) {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -2035,7 +2035,19 @@ impl<'a> TreeBuilder<'a> {
     }
 
     if token.is_end_tag() && token.tag_name() == "table" {
-      todo!("process_in_table_body: table end tag");
+      if !self
+        .open_elements
+        .has_oneof_element_names_in_table_scope(&["tbody", "tfoot", "thead"])
+      {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.open_elements.clear_back_to_table_body_context();
+      self.open_elements.pop();
+
+      self.switch_to(InsertMode::InTable);
+      return self.process(token);
     }
 
     if token.is_end_tag()

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -2143,8 +2143,80 @@ impl<'a> TreeBuilder<'a> {
     todo!("handle_in_column_group_mode");
   }
 
-  fn handle_in_caption_mode(&mut self, _token: Token) {
-    todo!("handle_in_caption_mode");
+  fn handle_in_caption_mode(&mut self, token: Token) {
+    if token.is_end_tag() && token.tag_name() == "caption" {
+      if !self.open_elements.has_element_name_in_table_scope("caption") {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != "caption" {
+        self.unexpected(&token);
+      }
+
+      self.open_elements.pop_until("caption");
+      self.active_formatting_elements.clear_up_to_last_marker();
+
+      self.switch_to(InsertMode::InTable);
+      return;
+    }
+
+    if token.is_start_tag()
+      && token.match_tag_name_in(&[
+        "caption", "col", "colgroup", "tbody", "td", "tfoot", "th", "thead",
+        "tr",
+      ])
+    {
+      if !self.open_elements.has_element_name_in_table_scope("caption") {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != "caption" {
+        self.unexpected(&token);
+      }
+
+      self.open_elements.pop_until("caption");
+      self.active_formatting_elements.clear_up_to_last_marker();
+
+      self.switch_to(InsertMode::InTable);
+      return self.process(token);
+    }
+
+    if token.is_end_tag() && token.tag_name() == "table" {
+      if !self.open_elements.has_element_name_in_table_scope("caption") {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != "caption" {
+        self.unexpected(&token);
+      }
+
+      self.open_elements.pop_until("caption");
+      self.active_formatting_elements.clear_up_to_last_marker();
+
+      self.switch_to(InsertMode::InTable);
+      return self.process(token);
+    }
+
+    if token.is_end_tag()
+      && token.match_tag_name_in(&[
+        "body", "col", "colgroup", "html", "tbody", "td", "tfoot", "th",
+        "thead", "tr",
+      ])
+    {
+      self.unexpected(&token);
+      return;
+    }
+
+    return self.handle_in_body_mode(token);
   }
 
   fn handle_in_select_mode(&mut self, _token: Token) {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1883,7 +1883,11 @@ impl<'a> TreeBuilder<'a> {
     }
 
     if token.is_start_tag() && token.tag_name() == "caption" {
-      todo!("process_in_table: caption start tag");
+      self.open_elements.clear_back_to_table_context();
+      self.active_formatting_elements.add_marker();
+      self.insert_html_element(token);
+      self.switch_to(InsertMode::InCaption);
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "colgroup" {

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1908,7 +1908,10 @@ impl<'a> TreeBuilder<'a> {
     }
 
     if token.is_start_tag() && token.match_tag_name_in(&["td", "th", "tr"]) {
-      todo!("process_in_table: td/th/tr start tag");
+      self.open_elements.clear_back_to_table_context();
+      self.insert_html_element(Token::new_start_tag_of("tbody"));
+      self.switch_to(InsertMode::InTableBody);
+      return self.process(token);
     }
 
     if token.is_start_tag() && token.tag_name() == "table" {

--- a/components/fast_html/src/tree_builder/stack_of_open_elements.rs
+++ b/components/fast_html/src/tree_builder/stack_of_open_elements.rs
@@ -116,6 +116,26 @@ impl StackOfOpenElements {
     false
   }
 
+  pub fn has_oneof_element_names_in_specific_scope(
+    &self,
+    tag_names: &[&str],
+    list: EcoVec<&str>,
+  ) -> bool {
+    for node in self.0.iter().rev() {
+      let element = node.as_element();
+
+      if tag_names.contains(&element.tag_name().as_str()) {
+        return true;
+      }
+
+      if list.contains(&element.tag_name().as_str()) {
+        return false;
+      }
+    }
+
+    false
+  }
+
   pub fn has_element_in_scope(&self, target_node: &NodePtr) -> bool {
     self
       .has_element_in_specific_scope(target_node, EcoVec::from(SCOPE_BASE_LIST))
@@ -158,6 +178,17 @@ impl StackOfOpenElements {
     list.push("table");
     list.push("template");
     self.has_element_name_in_specific_scope(tag_name, list)
+  }
+
+  pub fn has_oneof_element_names_in_table_scope(
+    &self,
+    tag_names: &[&str],
+  ) -> bool {
+    let mut list = EcoVec::from(SCOPE_BASE_LIST);
+    list.push("html");
+    list.push("table");
+    list.push("template");
+    self.has_oneof_element_names_in_specific_scope(tag_names, list)
   }
 
   /* pop ---------------------------------------- */

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1595,7 +1595,7 @@ impl<T: Tokenizing> TreeBuilder<T> {
       return;
     }
 
-    return self.process_in_body(token);
+    self.process_in_body(token)
   }
 
   fn process_in_select(&mut self, _token: Token) {

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1272,7 +1272,10 @@ impl<T: Tokenizing> TreeBuilder<T> {
     }
 
     if token.is_start_tag() && token.match_tag_name_in(&["td", "th", "tr"]) {
-      todo!("process_in_table: td/th/tr start tag");
+      self.open_elements.clear_back_to_table_context();
+      self.insert_html_element(Token::new_start_tag_of("tbody"));
+      self.switch_to(InsertMode::InTableBody);
+      return self.process(token);
     }
 
     if token.is_start_tag() && token.tag_name() == "table" {

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1507,8 +1507,80 @@ impl<T: Tokenizing> TreeBuilder<T> {
     todo!("process_in_column_group");
   }
 
-  fn process_in_caption(&mut self, _token: Token) {
-    todo!("process_in_caption");
+  fn process_in_caption(&mut self, token: Token) {
+    if token.is_end_tag() && token.tag_name() == "caption" {
+      if !self.open_elements.has_element_name_in_table_scope("caption") {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != "caption" {
+        self.unexpected(&token);
+      }
+
+      self.open_elements.pop_until("caption");
+      self.active_formatting_elements.clear_up_to_last_marker();
+
+      self.switch_to(InsertMode::InTable);
+      return;
+    }
+
+    if token.is_start_tag()
+      && token.match_tag_name_in(&[
+        "caption", "col", "colgroup", "tbody", "td", "tfoot", "th", "thead",
+        "tr",
+      ])
+    {
+      if !self.open_elements.has_element_name_in_table_scope("caption") {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != "caption" {
+        self.unexpected(&token);
+      }
+
+      self.open_elements.pop_until("caption");
+      self.active_formatting_elements.clear_up_to_last_marker();
+
+      self.switch_to(InsertMode::InTable);
+      return self.process(token);
+    }
+
+    if token.is_end_tag() && token.tag_name() == "table" {
+      if !self.open_elements.has_element_name_in_table_scope("caption") {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.generate_implied_end_tags("");
+
+      if self.current_node().as_element().tag_name() != "caption" {
+        self.unexpected(&token);
+      }
+
+      self.open_elements.pop_until("caption");
+      self.active_formatting_elements.clear_up_to_last_marker();
+
+      self.switch_to(InsertMode::InTable);
+      return self.process(token);
+    }
+
+    if token.is_end_tag()
+      && token.match_tag_name_in(&[
+        "body", "col", "colgroup", "html", "tbody", "td", "tfoot", "th",
+        "thead", "tr",
+      ])
+    {
+      self.unexpected(&token);
+      return;
+    }
+
+    return self.process_in_body(token);
   }
 
   fn process_in_select(&mut self, _token: Token) {

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1364,7 +1364,19 @@ impl<T: Tokenizing> TreeBuilder<T> {
     }
 
     if token.is_end_tag() && token.tag_name() == "table" {
-      todo!("process_in_table_body: table end tag");
+      if !self
+        .open_elements
+        .has_oneof_element_names_in_table_scope(&["tbody", "tfoot", "thead"])
+      {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.open_elements.clear_back_to_table_body_context();
+      self.open_elements.pop();
+
+      self.switch_to(InsertMode::InTable);
+      return self.process(token);
     }
 
     if token.is_end_tag()

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1247,7 +1247,11 @@ impl<T: Tokenizing> TreeBuilder<T> {
     }
 
     if token.is_start_tag() && token.tag_name() == "caption" {
-      todo!("process_in_table: caption start tag");
+      self.open_elements.clear_back_to_table_context();
+      self.active_formatting_elements.add_marker();
+      self.insert_html_element(token);
+      self.switch_to(InsertMode::InCaption);
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "colgroup" {

--- a/components/html/src/tree_builder/stack_of_open_elements.rs
+++ b/components/html/src/tree_builder/stack_of_open_elements.rs
@@ -116,6 +116,26 @@ impl StackOfOpenElements {
     false
   }
 
+  pub fn has_oneof_element_names_in_specific_scope(
+    &self,
+    tag_names: &[&str],
+    list: EcoVec<&str>,
+  ) -> bool {
+    for node in self.0.iter().rev() {
+      let element = node.as_element();
+
+      if tag_names.contains(&element.tag_name().as_str()) {
+        return true;
+      }
+
+      if list.contains(&element.tag_name().as_str()) {
+        return false;
+      }
+    }
+
+    false
+  }
+
   pub fn has_element_in_scope(&self, target_node: &NodePtr) -> bool {
     self
       .has_element_in_specific_scope(target_node, EcoVec::from(SCOPE_BASE_LIST))
@@ -158,6 +178,17 @@ impl StackOfOpenElements {
     list.push("table");
     list.push("template");
     self.has_element_name_in_specific_scope(tag_name, list)
+  }
+
+  pub fn has_oneof_element_names_in_table_scope(
+    &self,
+    tag_names: &[&str],
+  ) -> bool {
+    let mut list = EcoVec::from(SCOPE_BASE_LIST);
+    list.push("html");
+    list.push("table");
+    list.push("template");
+    self.has_oneof_element_names_in_specific_scope(tag_names, list)
   }
 
   /* pop ---------------------------------------- */

--- a/example/supported-tags.html
+++ b/example/supported-tags.html
@@ -72,6 +72,23 @@
           </tr>
         </tbody>
       </table>
+      <table>
+        <caption>
+          Example Caption
+        </caption>
+        <tr>
+          <th>Login</th>
+          <th>Email</th>
+        </tr>
+        <tr>
+          <td>user1</td>
+          <td>user1@sample.com</td>
+        </tr>
+        <tr>
+          <td>user2</td>
+          <td>user2@sample.com</td>
+        </tr>
+      </table>
       <section>
         <h2>Introduction</h2>
         <p>

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,18 +7,23 @@ const TARGET_HTML: &str = r#"<!DOCTYPE html>
 </head>
 <body>
 <table>
-  <thead>
-    <tr>
-      <th colspan="2">The table header</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>The table body</td>
-      <td>with two columns</td>
-    </tr>
-  </tbody>
+  <caption>
+    Example Caption
+  </caption>
+  <tr>
+    <th>Login</th>
+    <th>Email</th>
+  </tr>
+  <tr>
+    <td>user1</td>
+    <td>user1@sample.com</td>
+  </tr>
+  <tr>
+    <td>user2</td>
+    <td>user2@sample.com</td>
+  </tr>
 </table>
+
 
 </body>
 </html>"#;


### PR DESCRIPTION
こんな感じのHTMLが読めるように：

```html
<table>
  <caption>
    Example Caption
  </caption>
  <tr>
    <th>Login</th>
    <th>Email</th>
  </tr>
  <tr>
    <td>user1</td>
    <td>user1@sample.com</td>
  </tr>
  <tr>
    <td>user2</td>
    <td>user2@sample.com</td>
  </tr>
</table>
```