### PR TITLE
HTML Parser: table colgroupに対応

### DIFF
--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -2160,7 +2160,7 @@ impl<'a> TreeBuilder<'a> {
   fn handle_in_column_group_mode(&mut self, mut token: Token) {
     if let Token::Text(ref s) = token {
       if s.trim().is_empty() {
-        self.insert_str(&s);
+        self.insert_str(s);
         return;
       }
     }

--- a/components/fast_html/src/tree_builder/mod.rs
+++ b/components/fast_html/src/tree_builder/mod.rs
@@ -1891,7 +1891,10 @@ impl<'a> TreeBuilder<'a> {
     }
 
     if token.is_start_tag() && token.tag_name() == "colgroup" {
-      todo!("process_in_table: colgroup start tag");
+      self.open_elements.clear_back_to_table_context();
+      self.insert_html_element(token);
+      self.switch_to(InsertMode::InColumnGroup);
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "col" {

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1255,7 +1255,10 @@ impl<T: Tokenizing> TreeBuilder<T> {
     }
 
     if token.is_start_tag() && token.tag_name() == "colgroup" {
-      todo!("process_in_table: colgroup start tag");
+      self.open_elements.clear_back_to_table_context();
+      self.insert_html_element(token);
+      self.switch_to(InsertMode::InColumnGroup);
+      return;
     }
 
     if token.is_start_tag() && token.tag_name() == "col" {

--- a/components/html/src/tree_builder/mod.rs
+++ b/components/html/src/tree_builder/mod.rs
@@ -1521,8 +1521,68 @@ impl<T: Tokenizing> TreeBuilder<T> {
     self.process_in_body(token)
   }
 
-  fn process_in_column_group(&mut self, _token: Token) {
-    todo!("process_in_column_group");
+  fn process_in_column_group(&mut self, mut token: Token) {
+    if let Token::Character(c) = token {
+      if c.is_whitespace() {
+        self.insert_char(c);
+        return;
+      }
+    }
+
+    if let Token::Comment(text) = token {
+      self.insert_comment(text);
+      return;
+    }
+
+    if let Token::DOCTYPE { .. } = token {
+      self.unexpected(&token);
+      return;
+    }
+
+    if token.is_start_tag() && token.tag_name() == "html" {
+      return self.process_in_body(token);
+    }
+
+    if token.is_start_tag() && token.tag_name() == "col" {
+      token.acknowledge_self_closing_if_set();
+      self.insert_html_element(token);
+      self.open_elements.pop();
+      return;
+    }
+
+    if token.is_end_tag() && token.tag_name() == "colgroup" {
+      if self.current_node().as_element().tag_name() != "colgroup" {
+        self.unexpected(&token);
+        return;
+      }
+
+      self.open_elements.pop();
+      self.switch_to(InsertMode::InTable);
+
+      return;
+    }
+
+    if token.is_end_tag() && token.tag_name() == "col" {
+      self.unexpected(&token);
+      return;
+    }
+
+    if token.tag_name() == "template" {
+      return self.process_in_head(token);
+    }
+
+    if let Token::EOF = token {
+      return self.process_in_body(token);
+    }
+
+    if self.current_node().as_element().tag_name() != "colgroup" {
+      self.unexpected(&token);
+      return;
+    }
+
+    self.open_elements.pop();
+    self.switch_to(InsertMode::InTable);
+    self.process(token);
   }
 
   fn process_in_caption(&mut self, token: Token) {

--- a/example/supported-tags.html
+++ b/example/supported-tags.html
@@ -62,15 +62,26 @@
       <table>
         <thead>
           <tr>
-            <th colspan="2">The table header</th>
+            <th>Items</th>
+            <th scope="col">Expenditure</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>The table body</td>
-            <td>with two columns</td>
+            <th scope="row">Donuts</th>
+            <td>3,000</td>
+          </tr>
+          <tr>
+            <th scope="row">Stationery</th>
+            <td>18,000</td>
           </tr>
         </tbody>
+        <tfoot>
+          <tr>
+            <th scope="row">Totals</th>
+            <td>21,000</td>
+          </tr>
+        </tfoot>
       </table>
       <table>
         <caption>

--- a/example/supported-tags.html
+++ b/example/supported-tags.html
@@ -74,19 +74,26 @@
       </table>
       <table>
         <caption>
-          Example Caption
+          Superheros and sidekicks
         </caption>
+        <colgroup>
+          <col />
+          <col span="2" class="batman" />
+          <col span="2" class="flash" />
+        </colgroup>
         <tr>
-          <th>Login</th>
-          <th>Email</th>
+          <td> </td>
+          <th scope="col">Batman</th>
+          <th scope="col">Robin</th>
+          <th scope="col">The Flash</th>
+          <th scope="col">Kid Flash</th>
         </tr>
         <tr>
-          <td>user1</td>
-          <td>user1@sample.com</td>
-        </tr>
-        <tr>
-          <td>user2</td>
-          <td>user2@sample.com</td>
+          <th scope="row">Skill</th>
+          <td>Smarts</td>
+          <td>Dex, acrobat</td>
+          <td>Super speed</td>
+          <td>Super speed</td>
         </tr>
       </table>
       <section>

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,22 +8,28 @@ const TARGET_HTML: &str = r#"<!DOCTYPE html>
 <body>
 <table>
   <caption>
-    Example Caption
+    Superheros and sidekicks
   </caption>
+  <colgroup>
+    <col />
+    <col span="2" class="batman" />
+    <col span="2" class="flash" />
+  </colgroup>
   <tr>
-    <th>Login</th>
-    <th>Email</th>
+    <td> </td>
+    <th scope="col">Batman</th>
+    <th scope="col">Robin</th>
+    <th scope="col">The Flash</th>
+    <th scope="col">Kid Flash</th>
   </tr>
   <tr>
-    <td>user1</td>
-    <td>user1@sample.com</td>
-  </tr>
-  <tr>
-    <td>user2</td>
-    <td>user2@sample.com</td>
+    <th scope="row">Skill</th>
+    <td>Smarts</td>
+    <td>Dex, acrobat</td>
+    <td>Super speed</td>
+    <td>Super speed</td>
   </tr>
 </table>
-
 
 </body>
 </html>"#;


### PR DESCRIPTION
こんな感じのHTMLが読めるように：

```html
<table>
  <caption>
    Superheros and sidekicks
  </caption>
  <colgroup>
    <col />
    <col span="2" class="batman" />
    <col span="2" class="flash" />
  </colgroup>
  <tr>
    <td> </td>
    <th scope="col">Batman</th>
    <th scope="col">Robin</th>
    <th scope="col">The Flash</th>
    <th scope="col">Kid Flash</th>
  </tr>
  <tr>
    <th scope="row">Skill</th>
    <td>Smarts</td>
    <td>Dex, acrobat</td>
    <td>Super speed</td>
    <td>Super speed</td>
  </tr>
</table>
```

