### PR TITLE
HTML Parser: シングルクォート囲みの属性に対応

### DIFF
--- a/benchmark/compare_html_parser/data/supported-tags.html
+++ b/benchmark/compare_html_parser/data/supported-tags.html
@@ -125,6 +125,7 @@
           <!-- great text -->
           is a paragraph.
         </p>
+        <p title='John "ShotGun" Nelson'></p>
         <pre>
           L          TE
             A       A

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,7 @@ const TARGET_HTML: &str = r#"<!DOCTYPE html>
   <title>document title</title>
 </head>
 <body>
-<!-- <p>This is paragraph</p> -->
-<!--
-<p>Look at this cool image:</p>
-<img border="0" src="pic_trulli.jpg" alt="Trulli">
--->
-<p>This <!-- great text --> is a paragraph.</p>
+<p title='John "ShotGun" Nelson'></p>
 </body>
 </html>"#;
 


### PR DESCRIPTION
こんな感じのHTMLが読めるように：

```html
<p title='John "ShotGun" Nelson'></p>
```