### PR TITLE
invaidなHTML対応: invalid-first-character-of-tag-name （in EndTagOpen state）

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,6 @@
 use std::env;
 
-const TARGET_HTML: &str = r#"<!DOCTYPE html>
-<html>
-<head>
-  <title>document title</title>
-</head>
-<body>
-<p title='John "ShotGun" Nelson'></p>
-</body>
-</html>"#;
+const TARGET_HTML: &str = r#"<body></хелоу></body>"#;
 
 fn run_html(html: &str) {
   let document = html::debugger::get_document_from_html(html);


### PR DESCRIPTION
サンプル：
```html
<body></хелоу></body>
```

ref: https://htmlparser.info/parser/#tags-and-text