### PR TITLE
invalidなHTML対応：クォートで囲まれていない属性

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-const TARGET_HTML: &str = r#"<div class="a" class="b"></div>"#;
+const TARGET_HTML: &str = r#"<img src=1.png /re/>"#;
 
 fn run_html(html: &str) {
   let document = html::debugger::get_document_from_html(html);


### PR DESCRIPTION
```html
<img src=1.png /re/>
```

```
|-Document
    |-Element { tag_name: "html" }
        |-Element { tag_name: "head" }
        |-Element { tag_name: "body" }
            |-Element { tag_name: "img", attributes: {"src": "1.png", "re": ""} }
```

ref: https://htmlparser.info/parser/#attributes