### PR TITLE
HTML Parser: HashMapの代わりにFxHashMapを使う

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ name = "fast_dom"
 version = "0.1.0"
 dependencies = [
  "ecow",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,7 @@ dependencies = [
  "fast_dom",
  "log",
  "once_cell",
+ "rustc-hash",
  "serde_json",
  "tree",
 ]
@@ -984,6 +985,12 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/components/fast_dom/Cargo.toml
+++ b/components/fast_dom/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ecow = "0.2.0"
+ecow       = "0.2.0"
+rustc-hash = "1.1.0"

--- a/components/fast_dom/src/element.rs
+++ b/components/fast_dom/src/element.rs
@@ -1,10 +1,10 @@
+use rustc_hash::FxHashMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
 
 use ecow::EcoString;
 use ecow::EcoVec;
 
-type AttributeMap = HashMap<EcoString, EcoString>;
+type AttributeMap = FxHashMap<EcoString, EcoString>;
 type ClassList = EcoVec<EcoString>;
 
 pub struct Element {
@@ -19,7 +19,7 @@ impl Element {
     Self {
       tag_name: EcoString::from(tag_name),
       id: RefCell::new(None),
-      attributes: RefCell::new(AttributeMap::new()),
+      attributes: RefCell::new(AttributeMap::default()),
       class_list: RefCell::new(ClassList::new()),
     }
   }

--- a/components/fast_html/Cargo.toml
+++ b/components/fast_html/Cargo.toml
@@ -12,6 +12,7 @@ ecow       = "0.2.0"
 log        = "0.4.20"
 serde_json = "1.0.111"
 once_cell  = "1.19.0"
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/components/fast_html/Cargo.toml
+++ b/components/fast_html/Cargo.toml
@@ -32,3 +32,8 @@ harness = false
 name    = "with_attributes"
 path    = "benches/with_attributes.rs"
 harness = false
+
+[[bench]]
+name    = "named_char_ref"
+path    = "benches/named_char_ref.rs"
+harness = false

--- a/components/fast_html/benches/named_char_ref.rs
+++ b/components/fast_html/benches/named_char_ref.rs
@@ -1,0 +1,18 @@
+extern crate fast_html;
+
+use fast_html::debugger::*;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn parse_html_benchmark(c: &mut Criterion) {
+  c.bench_function("named_char_ref", |b| {
+    b.iter(|| {
+      let html =
+        r#"<p>Put the &lt;h1> at the beginning of the heading and the &lt;h1> at the end.</p>"#;
+      get_document_from_html(black_box(html));
+    })
+  });
+}
+
+criterion_group!(benches, parse_html_benchmark);
+criterion_main!(benches);

--- a/components/fast_html/src/debugger/mod.rs
+++ b/components/fast_html/src/debugger/mod.rs
@@ -1,7 +1,7 @@
 use super::tokenizer::Tokenizer;
 use super::tree_builder::TreeBuilder;
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use fast_dom::document::Document;
 use fast_dom::element::Element;
@@ -70,7 +70,7 @@ fn element_node_to_json(node: &Element) -> serde_json::Value {
     .borrow()
     .iter()
     .map(|(key, value)| (String::from(key), String::from(value)))
-    .collect::<HashMap<String, String>>();
+    .collect::<FxHashMap<String, String>>();
 
   let class_attribute = node.class_list().borrow().join(" ");
   if !class_attribute.is_empty() {

--- a/components/fast_html/src/tokenizer/entities.rs
+++ b/components/fast_html/src/tokenizer/entities.rs
@@ -1,8 +1,8 @@
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
-pub static ENTITIES: Lazy<HashMap<&str, (u32, u32)>> = Lazy::new(|| {
-  HashMap::from([
+pub static ENTITIES: Lazy<FxHashMap<&str, (u32, u32)>> = Lazy::new(|| {
+  [
     ("AElig", (198, 0)),
     ("AElig;", (198, 0)),
     ("AMP", (38, 0)),
@@ -2234,5 +2234,8 @@ pub static ENTITIES: Lazy<HashMap<&str, (u32, u32)>> = Lazy::new(|| {
     ("zscr;", (120015, 0)),
     ("zwj;", (8205, 0)),
     ("zwnj;", (8204, 0)),
-  ])
+  ]
+  .iter()
+  .cloned()
+  .collect()
 });


### PR DESCRIPTION
文字参照を含むHTMLの解析：
<img width="649" alt="スクリーンショット 2024-01-27 9 14 16" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/696dfbbe-4197-4a25-a885-a2a3ee6a5825">

対応している記法すべてを含むHTMLの解析：
<img width="652" alt="スクリーンショット 2024-01-27 9 20 53" src="https://github.com/tetracalibers/learn-browsers-work/assets/92695929/7b8299c0-3689-4222-bb80-57cafa5bb687">

