### PR TITLE
CSS Parser: StyleRuleのみを含むスタイルシートをパースできるように

### DIFF
--- a/components/css/src/parser/at_rule.rs
+++ b/components/css/src/parser/at_rule.rs
@@ -1,19 +1,76 @@
-use super::atomic::ComponentValue;
-use super::atomic::SimpleBlock;
+use nom::bytes::complete::tag;
+use nom::bytes::complete::take_until;
+use nom::character::complete::alpha1;
+use nom::character::complete::space1;
+use nom::combinator::map;
+use nom::combinator::opt;
+use nom::sequence::tuple;
+use nom::IResult;
 
-#[derive(Debug)]
-pub struct AtRule {
-  pub name: String,
-  pub prelude: Vec<ComponentValue>,
-  pub block: Option<SimpleBlock>,
+#[derive(Debug, PartialEq)]
+pub enum AtRule {
+  Regular(RegularAtRule),
+  Nested(NestedAtRule),
+  ConditionalGroup(ConditionalGroupAtRule),
 }
 
-impl AtRule {
-  pub fn new(name: String) -> Self {
-    Self {
-      name,
-      prelude: Vec::new(),
-      block: None,
-    }
+#[derive(Debug, PartialEq)]
+pub struct RegularAtRule {
+  name: String,
+  value: String,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct NestedAtRule {
+  name: String,
+  prelude: Vec<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ConditionalGroupAtRule {
+  name: String,
+  prelude: Vec<String>,
+  block: Vec<AtRule>,
+}
+
+fn at_rule_identifier(input: &str) -> IResult<&str, &str> {
+  let identifier_name = tuple((alpha1, opt(tuple((tag("-"), alpha1)))));
+
+  map(tuple((tag("@"), identifier_name)), |(_, (name, _))| name)(input)
+}
+
+fn regular_at_rule(input: &str) -> IResult<&str, AtRule> {
+  map(
+    tuple((at_rule_identifier, space1, take_until(";"), tag(";"))),
+    |(name, _, value, _)| {
+      AtRule::Regular(RegularAtRule {
+        name: name.to_string(),
+        value: value.to_string(),
+      })
+    },
+  )(input)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_at_rule_identifier() {
+    assert_eq!(at_rule_identifier("@import"), Ok(("", "import")));
+  }
+
+  #[test]
+  fn test_regular_at_rule() {
+    assert_eq!(
+      regular_at_rule("@import url(\"style.css\");"),
+      Ok((
+        "",
+        AtRule::Regular(RegularAtRule {
+          name: "import".to_string(),
+          value: "url(\"style.css\")".to_string(),
+        })
+      ))
+    );
   }
 }

--- a/components/css/src/parser/declaration.rs
+++ b/components/css/src/parser/declaration.rs
@@ -1,3 +1,4 @@
+use nom::bytes::complete::tag;
 use nom::character::complete::alpha0;
 use nom::character::complete::alpha1;
 use nom::character::complete::char;
@@ -13,6 +14,8 @@ use nom::IResult;
 
 use super::css_value::css_value;
 use super::css_value::CssValue;
+
+use super::utility::space_with_newline;
 
 #[derive(Debug, PartialEq)]
 pub struct Declaration {
@@ -53,10 +56,11 @@ fn important(input: &str) -> IResult<&str, bool> {
 pub fn declaration_list(input: &str) -> IResult<&str, Vec<Declaration>> {
   map(
     tuple((
-      separated_list1(tuple((space0, char(';'), space0)), declaration),
-      opt(tuple((char(';'), space0))),
+      separated_list1(tuple((space0, tag(";"), space0)), declaration),
+      opt(tag(";")),
+      opt(space_with_newline),
     )),
-    |(declarations, _)| declarations,
+    |(declarations, _, _)| declarations,
   )(input)
 }
 

--- a/components/css/src/parser/mod.rs
+++ b/components/css/src/parser/mod.rs
@@ -4,4 +4,5 @@ mod css_value;
 mod declaration;
 pub mod selector;
 mod style_rule;
-mod stylesheet;
+pub mod stylesheet;
+mod utility;

--- a/components/css/src/parser/selector.rs
+++ b/components/css/src/parser/selector.rs
@@ -23,6 +23,7 @@ pub type ComplexSelector = (CompoundSelector, Option<Combinator>);
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum SimpleSelector {
+  Universal,                            // *
   Id(String),                           // #id
   Class(String),                        // .class
   Type(String),                         // div
@@ -123,6 +124,10 @@ fn type_selector(input: &str) -> IResult<&str, SimpleSelector> {
   map(identifier, |name| SimpleSelector::Type(name))(input)
 }
 
+fn universal_selector(input: &str) -> IResult<&str, SimpleSelector> {
+  map(tag("*"), |_| SimpleSelector::Universal)(input)
+}
+
 fn id_selector(input: &str) -> IResult<&str, SimpleSelector> {
   map(tuple((tag("#"), identifier)), |(_, name)| {
     SimpleSelector::Id(name)
@@ -194,6 +199,7 @@ fn simple_selector(input: &str) -> IResult<&str, SimpleSelector> {
     attribute_selector,
     pseudo_element_selector,
     pseudo_class_selector,
+    universal_selector,
     type_selector,
   ))(input)
 }

--- a/components/css/src/parser/style_rule.rs
+++ b/components/css/src/parser/style_rule.rs
@@ -3,9 +3,9 @@ use super::declaration::Declaration;
 
 use super::selector::selector_list;
 use super::selector::SelectorList;
+use super::utility::space_with_newline;
 
 use nom::character::complete::char;
-use nom::character::complete::space0;
 use nom::combinator::map;
 use nom::sequence::tuple;
 use nom::IResult;
@@ -19,12 +19,13 @@ pub struct StyleRule {
 pub fn style_rule(input: &str) -> IResult<&str, StyleRule> {
   map(
     tuple((
+      space_with_newline,
       selector_list,
-      tuple((space0, char('{'), space0)),
+      tuple((space_with_newline, char('{'), space_with_newline)),
       declaration_list,
-      tuple((space0, char('}'), space0)),
+      tuple((space_with_newline, char('}'), space_with_newline)),
     )),
-    |(selector, _, declarations, _)| StyleRule {
+    |(_, selector, _, declarations, _)| StyleRule {
       selector,
       declarations,
     },
@@ -59,5 +60,29 @@ mod tests {
         }
       ))
     );
+
+    assert_eq!(
+      style_rule(
+        r#"
+        h1 {
+          font-weight: bold;
+        }
+        "#
+      ),
+      Ok((
+        "",
+        StyleRule {
+          selector: vec![vec![(
+            CompoundSelector(vec![SimpleSelector::Type("h1".to_string())]),
+            None
+          )],],
+          declarations: vec![Declaration {
+            name: "font-weight".to_string(),
+            value: vec![CssValue::Keyword("bold".to_string())],
+            important: false,
+          }],
+        }
+      ))
+    )
   }
 }

--- a/components/css/src/parser/stylesheet.rs
+++ b/components/css/src/parser/stylesheet.rs
@@ -1,12 +1,47 @@
-use super::at_rule::AtRule;
+use super::style_rule::style_rule;
 use super::style_rule::StyleRule;
 
+use super::utility::space_with_newline;
+
+use nom::combinator::map;
+use nom::multi::many0;
+use nom::sequence::tuple;
+use nom::IResult;
+
+#[derive(Debug, PartialEq)]
 pub struct StyleSheet {
   pub rules: Vec<Rule>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Rule {
   StyleRule(StyleRule),
-  AtRule(AtRule),
+  //AtRule(AtRule),
+}
+
+pub fn stylesheet(input: &str) -> IResult<&str, StyleSheet> {
+  map(
+    many0(tuple((
+      space_with_newline,
+      map(style_rule, |rule| Rule::StyleRule(rule)),
+      space_with_newline,
+    ))),
+    |result| StyleSheet {
+      rules: result.into_iter().map(|(_, rule, _)| rule).collect(),
+    },
+  )(input.trim())
+}
+
+pub fn main() {
+  let sample = r#"    
+    * {
+      display: inline;
+    }
+    
+    .aaa {
+      display: none;
+    }
+  "#;
+
+  println!("{:#?}", stylesheet(sample));
 }

--- a/components/css/src/parser/utility.rs
+++ b/components/css/src/parser/utility.rs
@@ -1,0 +1,10 @@
+use nom::character::complete::newline;
+use nom::character::complete::space0;
+use nom::combinator::map;
+use nom::combinator::opt;
+use nom::sequence::tuple;
+use nom::IResult;
+
+pub fn space_with_newline(input: &str) -> IResult<&str, &str> {
+  map(tuple((space0, opt(newline), space0)), |(_, _, _)| "")(input)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn run_fast_html(html: &str) {
 }
 
 fn run_css() {
-  css::parser::selector::main();
+  css::parser::stylesheet::main();
 }
 
 fn main() {


### PR DESCRIPTION
- Universalセレクタに対応
- 改行があっても問題なくパースできるように